### PR TITLE
Allow visitors to work on views

### DIFF
--- a/include/DataFrame/DataFrameVisitors.h
+++ b/include/DataFrame/DataFrameVisitors.h
@@ -584,7 +584,7 @@ struct DotProdVisitor  {
         dot_prod_ += (val1 * val2);
     }
     inline void pre ()  { dot_prod_ = value_type(0); }
-    inline void pro ()  {  }
+    inline void post ()  {  }
     inline result_type get_result () const  { return (dot_prod_); }
 
 private:

--- a/include/DataFrame/DataFrameVisitors.h
+++ b/include/DataFrame/DataFrameVisitors.h
@@ -1054,7 +1054,7 @@ struct ReturnVisitor  {
 
     explicit ReturnVisitor (return_policy rp) : ret_p_(rp)  {   }
     template<typename K, typename H> 
-    inline void operator() (const H &, const K &column)  {
+    inline void operator() (const K &, const H &column)  {
 
         const size_type col_len = column.template size<value_type>();
 

--- a/include/DataFrame/DataFrameVisitors.h
+++ b/include/DataFrame/DataFrameVisitors.h
@@ -615,13 +615,12 @@ public:
     inline SimpleRollAdopter(F &&functor, size_t r_count)
         : functor_(std::move(functor)), roll_count_(r_count)  {   }
 
-    inline void
-    operator() (const std::vector<index_type> &idx,
-                const std::vector<value_type> &column)  {
+    template<typename K, typename H> inline void
+    operator() (const K &idx, const H &column)  {
 
         if (roll_count_ == 0)  return;
 
-        const size_t    col_s = column.size();
+        const size_t    col_s = column.template size<value_type>();
 
         result_.reserve(col_s);
 
@@ -632,7 +631,7 @@ public:
 
             functor_.pre();
             for (size_t j = i; r < roll_count_ && j < col_s; ++j, ++r)
-                functor_(idx[j], column[j]);
+                functor_(idx.at(j), column.template at<value_type>(j));
             if (r == roll_count_)
                 result_.push_back(functor_.get_result());
             functor_.post();
@@ -806,20 +805,20 @@ struct CumSumVisitor {
     using size_type = std::size_t;
     using result_type = std::vector<value_type>;
 
-    inline void
-    operator() (const std::vector<index_type> &,
-                const std::vector<value_type> &column)  {
+    template<typename K, typename H> inline void
+    operator() (const K &, const H &column)  {
 
         value_type  running_sum = 0;
 
-        sum_.reserve(column.size());
-        for (const auto citer : column)  {
-            if (! skip_nan_ || ! is_nan__(citer))  {
-                running_sum += citer;
+        sum_.reserve(column.template size<value_type>());
+        for (auto citer = column.template begin<value_type>();
+             citer != column.template end<value_type>(); ++citer)  {
+            if (! skip_nan_ || ! is_nan__(*citer))  {
+                running_sum += *citer;
                 sum_.push_back(running_sum);
             }
             else
-                sum_.push_back(citer);
+                sum_.push_back(*citer);
         }
     }
     inline void pre ()  { sum_.clear(); }
@@ -847,20 +846,20 @@ struct CumProdVisitor {
     using size_type = std::size_t;
     using result_type = std::vector<value_type>;
 
-    inline void
-    operator() (const std::vector<index_type> &,
-                const std::vector<value_type> &column)  {
+    template<typename K, typename H> inline void
+    operator() (const K &, const H &column)  {
 
         value_type  running_prod = 1;
 
-        prod_.reserve(column.size());
-        for (const auto citer : column)  {
-            if (! skip_nan_ || ! is_nan__(citer))  {
-                running_prod *= citer;
+        prod_.reserve(column.template size<value_type>());
+        for (auto citer = column.template begin<value_type>();
+             citer != column.template end<value_type>(); ++citer)  {
+            if (! skip_nan_ || ! is_nan__(*citer))  {
+                running_prod *= *citer;
                 prod_.push_back(running_prod);
             }
             else
-                prod_.push_back(citer);
+                prod_.push_back(*citer);
         }
     }
     inline void pre ()  { prod_.clear(); }
@@ -885,23 +884,23 @@ struct CumMaxVisitor {
     using size_type = std::size_t;
     using result_type = std::vector<value_type>;
 
-    inline void
-    operator() (const std::vector<index_type> &,
-                const std::vector<value_type> &column)  {
+    template<typename K, typename H> inline void
+    operator() (const K &, const H &column)  {
 
-        if (column.empty())  return;
+        if (column.template empty<value_type>())  return;
 
-        value_type  running_max = column[0];
+        value_type  running_max = column.template at<value_type>(0);
 
-        max_.reserve(column.size());
-        for (const auto citer : column)  {
-            if (! skip_nan_ || ! is_nan__(citer))  {
-                if (citer > running_max)
-                    running_max = citer;
+        max_.reserve(column.template size<value_type>());
+        for (auto citer = column.template begin<value_type>();
+             citer != column.template end<value_type>(); ++citer)  {
+            if (! skip_nan_ || ! is_nan__(*citer))  {
+                if (*citer > running_max)
+                    running_max = *citer;
                 max_.push_back(running_max);
             }
             else
-                max_.push_back(citer);
+                max_.push_back(*citer);
         }
     }
     inline void pre ()  { max_.clear(); }
@@ -926,23 +925,23 @@ struct CumMinVisitor {
     using size_type = std::size_t;
     using result_type = std::vector<value_type>;
 
-    inline void
-    operator() (const std::vector<index_type> &,
-                const std::vector<value_type> &column)  {
+    template<typename K, typename H> inline void
+    operator() (const K &, const H &column)  {
 
-        if (column.empty())  return;
+        if (column.template empty<value_type>())  return;
 
-        value_type  running_min = column[0];
+        value_type  running_min = column.template at<value_type>(0);
 
-        min_.reserve(column.size());
-        for (const auto citer : column)  {
-            if (! skip_nan_ || ! is_nan__(citer))  {
-                if (citer < running_min)
-                    running_min = citer;
+        min_.reserve(column.template size<value_type>());
+        for (auto citer = column.template begin<value_type>();
+             citer != column.template end<value_type>(); ++citer)  {
+            if (! skip_nan_ || ! is_nan__(*citer))  {
+                if (*citer < running_min)
+                    running_min = *citer;
                 min_.push_back(running_min);
             }
             else
-                min_.push_back(citer);
+                min_.push_back(*citer);
         }
     }
     inline void pre ()  { min_.clear(); }
@@ -973,11 +972,11 @@ public:
     using result_type = std::vector<value_type>;
 
     AutoCorrVisitor () = default;
+    template<typename K, typename H>
     inline void
-    operator() (const std::vector<index_type> &,
-                const std::vector<value_type> &column)  {
+    operator() (const K &, const H &column)  {
 
-        const size_type col_len = column.size();
+        const size_type col_len = column.template size<value_type>();
 
         if (col_len <= 4)  return;
 
@@ -997,7 +996,7 @@ public:
             else  {
                 futures[thread_count] =
                     std::async(std::launch::async,
-                               &AutoCorrVisitor::get_auto_corr_,
+                               &AutoCorrVisitor::get_auto_corr_<H>,
                                this,
                                col_len,
                                lag,
@@ -1024,16 +1023,17 @@ private:
 
     using CorrResult = std::pair<size_type, value_type>;
 
-    inline CorrResult
+    template<typename H> inline CorrResult
     get_auto_corr_(size_type col_len,
                    size_type lag,
-                   const std::vector<value_type> &column) const  {
+                   const H &column) const  {
 
         CorrVisitor<value_type, index_type> corr {  };
 
         corr.pre();
         for (size_type i = 0; i < col_len - lag; ++i)
-            corr (I(), column[i], column[i + lag]);
+            corr (I(), column.template at<value_type>(i), 
+                  column.template at<value_type>(i + lag));
 
         return (CorrResult(lag, corr.get_result()));
     }
@@ -1053,10 +1053,10 @@ struct ReturnVisitor  {
     using result_type = std::vector<value_type>;
 
     explicit ReturnVisitor (return_policy rp) : ret_p_(rp)  {   }
-    inline void operator() (const std::vector<index_type> &,
-                            const std::vector<value_type> &column)  {
+    template<typename K, typename H> 
+    inline void operator() (const H &, const K &column)  {
 
-        const size_type col_len = column.size();
+        const size_type col_len = column.template size<value_type>();
 
         if (col_len < 3)  return;
 
@@ -1070,7 +1070,8 @@ struct ReturnVisitor  {
                     return (::log(lhs / rhs));
                 };
 
-            std::adjacent_difference (column.begin(), column.end(),
+            std::adjacent_difference (column.template begin<value_type>(), 
+                                      column.template end<value_type>(),
                                       std::back_inserter (tmp_result),
                                       func);
         }
@@ -1080,7 +1081,8 @@ struct ReturnVisitor  {
                 return ((lhs - rhs) / rhs);
             };
 
-            std::adjacent_difference (column.begin(), column.end(),
+            std::adjacent_difference (column.template begin<value_type>(), 
+                                      column.template end<value_type>(),
                                       std::back_inserter (tmp_result),
                                       func);
         }
@@ -1090,7 +1092,8 @@ struct ReturnVisitor  {
                 return (lhs - rhs);
             };
 
-            std::adjacent_difference (column.begin(), column.end(),
+            std::adjacent_difference (column.template begin<value_type>(), 
+                                      column.template end<value_type>(),
                                       std::back_inserter (tmp_result),
                                       func);
         }
@@ -1122,12 +1125,14 @@ struct KthValueVisitor  {
 
     explicit KthValueVisitor (size_type ke, bool skipnan = true)
         : kth_element_(ke), skip_nan_(skipnan)  {   }
+    template<typename K, typename H>
     inline void
-    operator() (const std::vector<index_type> &,
-                const std::vector<value_type> &column)  {
+    operator() (const K &, const H &column)  {
 
         result_ =
-            find_kth_element_ (column.begin(), column.end(), kth_element_);
+            find_kth_element_ (column.template begin<value_type>(), 
+                               column.template end<value_type>(), 
+                               kth_element_);
     }
     inline void pre ()  { result_ = value_type(); }
     inline void post ()  {   }
@@ -1139,9 +1144,9 @@ private:
     const size_type kth_element_;
     const bool      skip_nan_ { };
 
-    inline value_type
-    find_kth_element_ (typename std::vector<value_type>::const_iterator begin,
-                       typename std::vector<value_type>::const_iterator end,
+    template<typename It> inline value_type
+    find_kth_element_ (It begin,
+                       It end,
                        size_type k) const  {
 
         const size_type vec_size = static_cast<size_type>(end - begin);
@@ -1160,7 +1165,7 @@ private:
         }
 
         std::vector<value_type> tmp_vec (vec_size - 1);
-        value_type              kth_value = *(begin + (vec_size / 2));
+        value_type              kth_value = *(begin + static_cast<long>(vec_size / 2));
         size_type               less_count = 0;
         size_type               great_count = vec_size - 2;
 
@@ -1200,11 +1205,12 @@ struct MedianVisitor  {
     using result_type = T;
 
     MedianVisitor () = default;
+    template<typename K, typename H>
     inline void
-    operator() (const std::vector<index_type> &idx,
-                const std::vector<value_type> &column)  {
+    operator() (const K &idx, const H &column)  {
 
-        const size_type                         vec_size = column.size();
+        const size_type                         vec_size = 
+            column.template size<value_type>();
         KthValueVisitor<value_type, index_type> kv_visitor (vec_size >> 1);
 
 
@@ -1262,17 +1268,18 @@ struct  ModeVisitor {
 
     using result_type = std::array<DataItem, N>;
 
+    template<typename K, typename H>
     inline void
-    operator() (const std::vector<index_type> &idx,
-                const std::vector<value_type> &column)  {
+    operator() (const K &idx, const H &column)  {
 
         DataItem                                    nan_item(
             std::numeric_limits<value_type>::quiet_NaN());
-        const size_type                             col_size = column.size();
+        const size_type                             col_size = 
+            column.template size<value_type>();
         std::unordered_map<value_type, DataItem>    val_map (col_size);
 
         for (size_type i = 0; i < col_size; ++i)  {
-            if (is_nan__(column[i]))  {
+            if (is_nan__(column.template at<value_type>(i)))  {
                 nan_item.indices.push_back(idx[i]);
                 nan_item.value_indices_in_col.push_back(i);
             }
@@ -1280,7 +1287,8 @@ struct  ModeVisitor {
                 auto    ret =
                     val_map.emplace(
                         std::pair<value_type, DataItem>(
-                            column[i], DataItem(column[i])));
+                            column.template at<value_type>(i), 
+                            DataItem(column.template at<value_type>(i))));
 
                 ret.first->second.indices.push_back(idx[i]);
                 ret.first->second.value_indices_in_col.push_back(i);
@@ -1344,10 +1352,11 @@ struct DiffVisitor  {
     explicit DiffVisitor(long periods = 1, bool skipnan = true)
         : periods_(periods), skip_nan_(skipnan) {  }
 
-    inline void operator() (const std::vector<index_type> &,
-                            const std::vector<value_type> &column)  {
+    template<typename K, typename H>
+    inline void 
+    operator() (const K &, const H &column)  {
 
-        const size_type col_len = column.size();
+        const size_type col_len = column.template size<value_type>();
 
         result_.reserve(col_len);
         if (periods_ >= 0)  {
@@ -1357,16 +1366,17 @@ struct DiffVisitor  {
                     result_.push_back(
                         std::numeric_limits<value_type>::quiet_NaN());
             }
-            for (auto i = column.begin() + periods_, j = column.begin();
-                 i < column.end(); ++i, ++j) {
+            for (auto i = column.template begin<value_type>() + periods_, 
+                      j = column.template begin<value_type>();
+                 i < column.template end<value_type>(); ++i, ++j) {
                 if (skip_nan_ && (is_nan__(*i) || is_nan__(*j)))  continue;
                 result_.push_back(*i - *j);
             }
         }
         else {
-            for (auto i = column.rbegin() + std::abs(periods_),
-                      j = column.rbegin();
-                 i < column.rend(); ++i, ++j) {
+            for (auto i = column.template rbegin<value_type>() + std::abs(periods_),
+                      j = column.template rbegin<value_type>();
+                 i < column.template rend<value_type>(); ++i, ++j) {
                 if (skip_nan_ && (is_nan__(*i) || is_nan__(*j)))  continue;
                 result_.insert(result_.begin(), (*i - *j));
             }
@@ -1405,20 +1415,20 @@ struct ZScoreVisitor {
     using size_type = std::size_t;
     using result_type = std::vector<value_type>;
 
+    template<typename K, typename H>
     inline void
-    operator() (const std::vector<index_type> &idx,
-                const std::vector<value_type> &col)  {
+    operator() (const K &idx, const H &col)  {
 
         MeanVisitor<value_type> mvisit;
         StdVisitor<value_type>  svisit;
-        const size_type         col_s = col.size();
+        const size_type         col_s = col.template size<value_type>();
 
         mvisit.pre();
         svisit.pre();
         for (size_type i = 0; i < col_s; ++i)  {
-            if (! skip_nan_ || ! is_nan__(col[i]))  {
-                mvisit(idx[i], col[i]);
-                svisit(idx[i], col[i]);
+            if (! skip_nan_ || ! is_nan__(col.template at<value_type>(i)))  {
+                mvisit(idx[i], col.template at<value_type>(i));
+                svisit(idx[i], col.template at<value_type>(i));
             }
         }
         mvisit.post();
@@ -1427,9 +1437,10 @@ struct ZScoreVisitor {
         const value_type    m = mvisit.get_result();
         const value_type    s = svisit.get_result();
 
-        zscore_.reserve(col.size());
-        for (const auto citer : col)
-            zscore_.push_back((citer - m) / s);
+        zscore_.reserve(col.template size<value_type>());
+        for (auto citer = col.template begin<value_type>();
+             citer != col.template end<value_type>(); ++citer)
+            zscore_.push_back(((*citer) - m) / s);
     }
     inline void pre ()  { zscore_.clear(); }
     inline void post ()  {  }

--- a/include/DataFrame/Internals/DataFrame_get.tcc
+++ b/include/DataFrame/Internals/DataFrame_get.tcc
@@ -528,8 +528,13 @@ single_act_visit (const char *name, V &visitor) const  {
         throw ColNotFound (buffer);
     }
 
+    const DataVec           &hv = data_[iter->second];
+    SpinGuard               guard(lock_);
+    const std::vector<T>    &vec = hv.template get_vector<T>();
+
+    guard.release();
     visitor.pre();
-    visitor (indices_, data_[iter->second]);
+    visitor (indices_, vec);
     visitor.post();
 
     return (visitor);

--- a/include/DataFrame/Internals/DataFrame_get.tcc
+++ b/include/DataFrame/Internals/DataFrame_get.tcc
@@ -210,13 +210,17 @@ V &DataFrame<I, H>::visit (const char *name, V &visitor)  {
     }
 
     DataVec         &hv = data_[iter->second];
+    SpinGuard       guard(lock_);
+    std::vector<T>  &vec = hv.template get_vector<T>();
+
+    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s = hv.template size<T>();
+    const size_type data_s = vec.size();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
-        visitor (indices_[i], i < data_s ? hv.template at<T>(i) : _get_nan<T>());
+        visitor (indices_[i], i < data_s ? vec[i] : _get_nan<T>());
     visitor.post();
 
     return (visitor);
@@ -251,16 +255,21 @@ visit (const char *name1, const char *name2, V &visitor)  {
 
     DataVec         &hv1 = data_[iter1->second];
     DataVec         &hv2 = data_[iter2->second];
+    SpinGuard       guard(lock_);
+    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
+    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
+
+    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = hv1.template size<T1>();
-    const size_type data_s2 = hv2.template size<T2>();
+    const size_type data_s1 = vec1.size();
+    const size_type data_s2 = vec2.size();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
-                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>());
+                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
+                 i < data_s2 ? vec2[i] : _get_nan<T2>());
     visitor.post();
 
     return (visitor);
@@ -305,18 +314,24 @@ visit (const char *name1, const char *name2, const char *name3, V &visitor)  {
     DataVec         &hv1 = data_[iter1->second];
     DataVec         &hv2 = data_[iter2->second];
     DataVec         &hv3 = data_[iter3->second];
+    SpinGuard       guard(lock_);
+    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
+    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
+    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
+
+    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = hv1.template size<T1>();
-    const size_type data_s2 = hv2.template size<T2>();
-    const size_type data_s3 = hv3.template size<T3>();
+    const size_type data_s1 = vec1.size();
+    const size_type data_s2 = vec2.size();
+    const size_type data_s3 = vec3.size();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
-                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>(),
-                 i < data_s3 ? hv3.template at<T3>(i) : _get_nan<T3>());
+                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
+                 i < data_s2 ? vec2[i] : _get_nan<T2>(),
+                 i < data_s3 ? vec3[i] : _get_nan<T3>());
     visitor.post();
 
     return (visitor);
@@ -375,20 +390,27 @@ visit (const char *name1,
     DataVec         &hv2 = data_[iter2->second];
     DataVec         &hv3 = data_[iter3->second];
     DataVec         &hv4 = data_[iter4->second];
+    SpinGuard       guard(lock_);
+    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
+    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
+    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
+    std::vector<T4> &vec4 = hv4.template get_vector<T4>();
+
+    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = hv1.template size<T1>();
-    const size_type data_s2 = hv2.template size<T2>();
-    const size_type data_s3 = hv3.template size<T3>();
-    const size_type data_s4 = hv4.template size<T4>();
+    const size_type data_s1 = vec1.size();
+    const size_type data_s2 = vec2.size();
+    const size_type data_s3 = vec3.size();
+    const size_type data_s4 = vec4.size();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
-                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>(),
-                 i < data_s3 ? hv3.template at<T3>(i) : _get_nan<T3>(),
-                 i < data_s4 ? hv4.template at<T4>(i) : _get_nan<T4>());
+                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
+                 i < data_s2 ? vec2[i] : _get_nan<T2>(),
+                 i < data_s3 ? vec3[i] : _get_nan<T3>(),
+                 i < data_s4 ? vec4[i] : _get_nan<T4>());
     visitor.post();
 
     return (visitor);
@@ -459,22 +481,30 @@ visit (const char *name1,
     DataVec         &hv3 = data_[iter3->second];
     DataVec         &hv4 = data_[iter4->second];
     DataVec         &hv5 = data_[iter5->second];
+    SpinGuard       guard(lock_);
+    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
+    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
+    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
+    std::vector<T4> &vec4 = hv4.template get_vector<T4>();
+    std::vector<T5> &vec5 = hv5.template get_vector<T5>();
+
+    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = hv1.template size<T1>();
-    const size_type data_s2 = hv2.template size<T2>();
-    const size_type data_s3 = hv3.template size<T3>();
-    const size_type data_s4 = hv4.template size<T4>();
-    const size_type data_s5 = hv5.template size<T5>();
+    const size_type data_s1 = vec1.size();
+    const size_type data_s2 = vec2.size();
+    const size_type data_s3 = vec3.size();
+    const size_type data_s4 = vec4.size();
+    const size_type data_s5 = vec5.size();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
-                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>(),
-                 i < data_s3 ? hv3.template at<T3>(i) : _get_nan<T3>(),
-                 i < data_s4 ? hv4.template at<T4>(i) : _get_nan<T4>(),
-                 i < data_s5 ? hv5.template at<T5>(i) : _get_nan<T5>());
+                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
+                 i < data_s2 ? vec2[i] : _get_nan<T2>(),
+                 i < data_s3 ? vec3[i] : _get_nan<T3>(),
+                 i < data_s4 ? vec4[i] : _get_nan<T4>(),
+                 i < data_s5 ? vec5[i] : _get_nan<T5>());
     visitor.post();
 
     return (visitor);

--- a/include/DataFrame/Internals/DataFrame_get.tcc
+++ b/include/DataFrame/Internals/DataFrame_get.tcc
@@ -498,13 +498,8 @@ single_act_visit (const char *name, V &visitor) const  {
         throw ColNotFound (buffer);
     }
 
-    const DataVec           &hv = data_[iter->second];
-    SpinGuard               guard(lock_);
-    const std::vector<T>    &vec = hv.template get_vector<T>();
-
-    guard.release();
     visitor.pre();
-    visitor (indices_, vec);
+    visitor (indices_, data_[iter->second]);
     visitor.post();
 
     return (visitor);

--- a/include/DataFrame/Internals/DataFrame_get.tcc
+++ b/include/DataFrame/Internals/DataFrame_get.tcc
@@ -210,17 +210,13 @@ V &DataFrame<I, H>::visit (const char *name, V &visitor)  {
     }
 
     DataVec         &hv = data_[iter->second];
-    SpinGuard       guard(lock_);
-    std::vector<T>  &vec = hv.template get_vector<T>();
-
-    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s = vec.size();
+    const size_type data_s = hv.template size<T>();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
-        visitor (indices_[i], i < data_s ? vec[i] : _get_nan<T>());
+        visitor (indices_[i], i < data_s ? hv.template at<T>(i) : _get_nan<T>());
     visitor.post();
 
     return (visitor);
@@ -255,21 +251,16 @@ visit (const char *name1, const char *name2, V &visitor)  {
 
     DataVec         &hv1 = data_[iter1->second];
     DataVec         &hv2 = data_[iter2->second];
-    SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
-
-    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = vec1.size();
-    const size_type data_s2 = vec2.size();
+    const size_type data_s1 = hv1.template size<T1>();
+    const size_type data_s2 = hv2.template size<T2>();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
-                 i < data_s2 ? vec2[i] : _get_nan<T2>());
+                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
+                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>());
     visitor.post();
 
     return (visitor);
@@ -314,24 +305,18 @@ visit (const char *name1, const char *name2, const char *name3, V &visitor)  {
     DataVec         &hv1 = data_[iter1->second];
     DataVec         &hv2 = data_[iter2->second];
     DataVec         &hv3 = data_[iter3->second];
-    SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
-    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
-
-    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = vec1.size();
-    const size_type data_s2 = vec2.size();
-    const size_type data_s3 = vec3.size();
+    const size_type data_s1 = hv1.template size<T1>();
+    const size_type data_s2 = hv2.template size<T2>();
+    const size_type data_s3 = hv3.template size<T3>();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
-                 i < data_s2 ? vec2[i] : _get_nan<T2>(),
-                 i < data_s3 ? vec3[i] : _get_nan<T3>());
+                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
+                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>(),
+                 i < data_s3 ? hv3.template at<T3>(i) : _get_nan<T3>());
     visitor.post();
 
     return (visitor);
@@ -390,27 +375,20 @@ visit (const char *name1,
     DataVec         &hv2 = data_[iter2->second];
     DataVec         &hv3 = data_[iter3->second];
     DataVec         &hv4 = data_[iter4->second];
-    SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
-    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
-    std::vector<T4> &vec4 = hv4.template get_vector<T4>();
-
-    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = vec1.size();
-    const size_type data_s2 = vec2.size();
-    const size_type data_s3 = vec3.size();
-    const size_type data_s4 = vec4.size();
+    const size_type data_s1 = hv1.template size<T1>();
+    const size_type data_s2 = hv2.template size<T2>();
+    const size_type data_s3 = hv3.template size<T3>();
+    const size_type data_s4 = hv4.template size<T4>();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
-                 i < data_s2 ? vec2[i] : _get_nan<T2>(),
-                 i < data_s3 ? vec3[i] : _get_nan<T3>(),
-                 i < data_s4 ? vec4[i] : _get_nan<T4>());
+                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
+                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>(),
+                 i < data_s3 ? hv3.template at<T3>(i) : _get_nan<T3>(),
+                 i < data_s4 ? hv4.template at<T4>(i) : _get_nan<T4>());
     visitor.post();
 
     return (visitor);
@@ -481,30 +459,22 @@ visit (const char *name1,
     DataVec         &hv3 = data_[iter3->second];
     DataVec         &hv4 = data_[iter4->second];
     DataVec         &hv5 = data_[iter5->second];
-    SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
-    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
-    std::vector<T4> &vec4 = hv4.template get_vector<T4>();
-    std::vector<T5> &vec5 = hv5.template get_vector<T5>();
-
-    guard.release();
 
     const size_type idx_s = indices_.size();
-    const size_type data_s1 = vec1.size();
-    const size_type data_s2 = vec2.size();
-    const size_type data_s3 = vec3.size();
-    const size_type data_s4 = vec4.size();
-    const size_type data_s5 = vec5.size();
+    const size_type data_s1 = hv1.template size<T1>();
+    const size_type data_s2 = hv2.template size<T2>();
+    const size_type data_s3 = hv3.template size<T3>();
+    const size_type data_s4 = hv4.template size<T4>();
+    const size_type data_s5 = hv5.template size<T5>();
 
     visitor.pre();
     for (size_type i = 0; i < idx_s; ++i)
         visitor (indices_[i],
-                 i < data_s1 ? vec1[i] : _get_nan<T1>(),
-                 i < data_s2 ? vec2[i] : _get_nan<T2>(),
-                 i < data_s3 ? vec3[i] : _get_nan<T3>(),
-                 i < data_s4 ? vec4[i] : _get_nan<T4>(),
-                 i < data_s5 ? vec5[i] : _get_nan<T5>());
+                 i < data_s1 ? hv1.template at<T1>(i) : _get_nan<T1>(),
+                 i < data_s2 ? hv2.template at<T2>(i) : _get_nan<T2>(),
+                 i < data_s3 ? hv3.template at<T3>(i) : _get_nan<T3>(),
+                 i < data_s4 ? hv4.template at<T4>(i) : _get_nan<T4>(),
+                 i < data_s5 ? hv5.template at<T5>(i) : _get_nan<T5>());
     visitor.post();
 
     return (visitor);

--- a/include/DataFrame/Internals/DataFrame_get.tcc
+++ b/include/DataFrame/Internals/DataFrame_get.tcc
@@ -211,7 +211,7 @@ V &DataFrame<I, H>::visit (const char *name, V &visitor)  {
 
     DataVec         &hv = data_[iter->second];
     SpinGuard       guard(lock_);
-    std::vector<T>  &vec = hv.template get_vector<T>();
+    auto            &vec = hv.template get_vector<T>();
 
     guard.release();
 
@@ -256,8 +256,8 @@ visit (const char *name1, const char *name2, V &visitor)  {
     DataVec         &hv1 = data_[iter1->second];
     DataVec         &hv2 = data_[iter2->second];
     SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
+    auto            &vec1 = hv1.template get_vector<T1>();
+    auto            &vec2 = hv2.template get_vector<T2>();
 
     guard.release();
 
@@ -315,9 +315,9 @@ visit (const char *name1, const char *name2, const char *name3, V &visitor)  {
     DataVec         &hv2 = data_[iter2->second];
     DataVec         &hv3 = data_[iter3->second];
     SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
-    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
+    auto            &vec1 = hv1.template get_vector<T1>();
+    auto            &vec2 = hv2.template get_vector<T2>();
+    auto            &vec3 = hv3.template get_vector<T3>();
 
     guard.release();
 
@@ -391,10 +391,10 @@ visit (const char *name1,
     DataVec         &hv3 = data_[iter3->second];
     DataVec         &hv4 = data_[iter4->second];
     SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
-    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
-    std::vector<T4> &vec4 = hv4.template get_vector<T4>();
+    auto            &vec1 = hv1.template get_vector<T1>();
+    auto            &vec2 = hv2.template get_vector<T2>();
+    auto            &vec3 = hv3.template get_vector<T3>();
+    auto            &vec4 = hv4.template get_vector<T4>();
 
     guard.release();
 
@@ -482,11 +482,11 @@ visit (const char *name1,
     DataVec         &hv4 = data_[iter4->second];
     DataVec         &hv5 = data_[iter5->second];
     SpinGuard       guard(lock_);
-    std::vector<T1> &vec1 = hv1.template get_vector<T1>();
-    std::vector<T2> &vec2 = hv2.template get_vector<T2>();
-    std::vector<T3> &vec3 = hv3.template get_vector<T3>();
-    std::vector<T4> &vec4 = hv4.template get_vector<T4>();
-    std::vector<T5> &vec5 = hv5.template get_vector<T5>();
+    auto            &vec1 = hv1.template get_vector<T1>();
+    auto            &vec2 = hv2.template get_vector<T2>();
+    auto            &vec3 = hv3.template get_vector<T3>();
+    auto            &vec4 = hv4.template get_vector<T4>();
+    auto            &vec5 = hv5.template get_vector<T5>();
 
     guard.release();
 
@@ -530,7 +530,7 @@ single_act_visit (const char *name, V &visitor) const  {
 
     const DataVec           &hv = data_[iter->second];
     SpinGuard               guard(lock_);
-    const std::vector<T>    &vec = hv.template get_vector<T>();
+    auto                    &vec = hv.template get_vector<T>();
 
     guard.release();
     visitor.pre();

--- a/include/DataFrame/Vectors/HeteroVector.h
+++ b/include/DataFrame/Vectors/HeteroVector.h
@@ -96,6 +96,47 @@ public:
     template<typename T>
     const T &front() const;
 
+    template<typename T>
+    using iterator = typename std::vector<T>::iterator;
+    template<typename T>
+    using const_iterator = typename std::vector<T>::const_iterator;
+    template<typename T>
+    using reverse_iterator = typename std::vector<T>::reverse_iterator;
+    template<typename T>
+    using const_reverse_iterator = typename std::vector<T>::const_reverse_iterator;
+
+    template<typename T>
+    inline iterator<T>
+    begin() noexcept { return (get_vector<T>().begin()); }
+
+    template<typename T>
+    inline iterator<T>
+    end() noexcept { return (get_vector<T>().end()); }
+
+    template<typename T>
+    inline const_iterator<T>
+    begin () const noexcept { return (get_vector<T>().begin()); }
+
+    template<typename T>
+    inline const_iterator<T>
+    end () const noexcept { return (get_vector<T>().end()); }
+
+    template<typename T>
+    inline reverse_iterator<T>
+    rbegin() noexcept { return (get_vector<T>().rbegin()); }
+
+    template<typename T>
+    inline reverse_iterator<T>
+    rend() noexcept { return (get_vector<T>().rend()); }
+
+    template<typename T>
+    inline const_reverse_iterator<T>
+    rbegin () const noexcept { return (get_vector<T>().rbegin()); }
+
+    template<typename T>
+    inline const_reverse_iterator<T>
+    rend () const noexcept { return (get_vector<T>().rend()); }
+
 private:
 
     template<typename T>

--- a/include/DataFrame/Vectors/HeteroView.h
+++ b/include/DataFrame/Vectors/HeteroView.h
@@ -61,6 +61,35 @@ public:
     template<typename T>
     const T &front() const;
 
+    template<typename T>
+    using iterator = typename VectorView<T>::iterator;
+    template<typename T>
+    using const_iterator = typename VectorView<T>::const_iterator;
+    template<typename T>
+    using reverse_iterator = typename VectorView<T>::reverse_iterator;
+    template<typename T>
+    using const_reverse_iterator = typename VectorView<T>::const_reverse_iterator;
+
+    template<typename T>
+    iterator<T> begin();
+    template<typename T>
+    const_iterator<T> begin() const;
+
+    template<typename T>
+    iterator<T> end();
+    template<typename T>
+    const_iterator<T> end() const;
+
+    template<typename T>
+    reverse_iterator<T> rbegin();
+    template<typename T>
+    const_reverse_iterator<T> rbegin() const;
+
+    template<typename T>
+    reverse_iterator<T> rend();
+    template<typename T>
+    const_reverse_iterator<T> rend() const;
+
 private:
 
     template<typename T>

--- a/include/DataFrame/Vectors/HeteroView.tcc
+++ b/include/DataFrame/Vectors/HeteroView.tcc
@@ -205,6 +205,55 @@ T &HeteroView::front()  { return (get_vector<T>().front ()); }
 template<typename T>
 const T &HeteroView::front() const  { return (get_vector<T>().front ()); }
 
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::iterator<T>
+HeteroView::begin()  { return (get_vector<T>().begin ()); }
+
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::const_iterator<T>
+HeteroView::begin() const  { return (get_vector<T>().begin ()); }
+
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::iterator<T>
+HeteroView::end()  { return (get_vector<T>().end ()); }
+
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::const_iterator<T>
+HeteroView::end() const  { return (get_vector<T>().end ()); }
+
+
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::reverse_iterator<T>
+HeteroView::rbegin()  { return (get_vector<T>().rbegin ()); }
+
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::const_reverse_iterator<T>
+HeteroView::rbegin() const  { return (get_vector<T>().rbegin ()); }
+
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::reverse_iterator<T>
+HeteroView::rend()  { return (get_vector<T>().rend ()); }
+
+// ----------------------------------------------------------------------------
+
+template<typename T>
+HeteroView::const_reverse_iterator<T>
+HeteroView::rend() const  { return (get_vector<T>().rend ()); }
+
 } // namespace hmdf
 
 // ----------------------------------------------------------------------------

--- a/include/DataFrame/Vectors/VectorView.h
+++ b/include/DataFrame/Vectors/VectorView.h
@@ -145,7 +145,7 @@ public:
 
             return (*node_);
         }
-        inline operator pointer () const noexcept  { return (node_); }
+        inline operator const_pointer () const noexcept  { return (node_); }
 
        // ++Prefix
        //

--- a/test/dataframe_tester.cc
+++ b/test/dataframe_tester.cc
@@ -3606,6 +3606,41 @@ static void test_thread_safety()  {
 
 // -----------------------------------------------------------------------------
 
+static void test_view_visitors()  {
+
+    std::cout << "\nTesting View visitors ..." << std::endl;
+
+    MyDataFrame         df;
+
+    std::vector<unsigned long>  idxvec = { 1UL, 2UL, 3UL, 4UL, 5UL };
+    std::vector<double>         dblvec1 = { 1.1, 2.2, 3.3, 4.4, 5.5 };
+    std::vector<double>         dblvec2 = { 2.2, 3.3, 4.4, 5.5, 6.6 };
+    std::vector<double>         dblvec3 = { 3.3, 4.4, 5.5, 6.6, 7.7 };
+    std::vector<double>         dblvec4 = { 4.4, 5.5, 6.6, 7.7, 8.8 };
+    std::vector<double>         dblvec5 = { 5.5, 6.6, 7.7, 8.8, 9.9 };
+
+    df.load_data(std::move(idxvec), 
+                 std::make_pair("dbl_col1", dblvec1),
+                 std::make_pair("dbl_col2", dblvec2),
+                 std::make_pair("dbl_col3", dblvec3),
+                 std::make_pair("dbl_col4", dblvec4),
+                 std::make_pair("dbl_col5", dblvec5));
+
+    typedef DataFrameView<unsigned long> MyDataFrameView;
+
+    MyDataFrameView dfv = 
+        df.get_view_by_idx<double>(Index2D<unsigned long> { 3, 5 });
+    MeanVisitor<double> mean_visitor;
+    assert(abs(dfv.visit<double>("dbl_col1", 
+                                 mean_visitor).get_result() - 4.4) < 0.00001);
+
+    DotProdVisitor<double> dp_visitor;
+    assert(abs(dfv.visit<double, double>("dbl_col1", "dbl_col2", 
+                                 dp_visitor).get_result() - 75.02) < 0.00001);
+}
+
+// -----------------------------------------------------------------------------
+
 int main(int argc, char *argv[]) {
 
     test_haphazard();
@@ -3667,6 +3702,7 @@ int main(int argc, char *argv[]) {
     test_get_view_by_idx_values();
     test_z_score_visitor();
     test_thread_safety();
+    test_view_visitors();
 
     return (0);
 }

--- a/test/dataframe_tester.cc
+++ b/test/dataframe_tester.cc
@@ -3612,31 +3612,111 @@ static void test_view_visitors()  {
 
     MyDataFrame         df;
 
-    std::vector<unsigned long>  idxvec = { 1UL, 2UL, 3UL, 4UL, 5UL };
+    std::vector<unsigned long>  idxvec = { 1UL, 2UL, 3UL, 4UL, 5UL,
+                                           6UL, 7UL, 8UL, 9UL, 10UL };
     std::vector<double>         dblvec1 = { 1.1, 2.2, 3.3, 4.4, 5.5 };
     std::vector<double>         dblvec2 = { 2.2, 3.3, 4.4, 5.5, 6.6 };
-    std::vector<double>         dblvec3 = { 3.3, 4.4, 5.5, 6.6, 7.7 };
-    std::vector<double>         dblvec4 = { 4.4, 5.5, 6.6, 7.7, 8.8 };
-    std::vector<double>         dblvec5 = { 5.5, 6.6, 7.7, 8.8, 9.9 };
+    std::vector<double>         dblvec3 = { 0.0, 1.1, 2.2, 3.3, 4.4,
+                                            5.5, 6.6, 7.7, 8.8, 9.9 };
+    std::vector<double>         dblvec4 = { 5.9, 4.4, 1.0, 9.8, 5.3,
+                                            7.2, 3.8, 4.1 };
+    std::vector<double>         dblvec5 = { 1.1, 5.9, 4.4, 1.0, 9.8,
+                                            5.3, 7.2, 3.8, 4.1, 10.1 };
+    std::vector<double>         dblvec6 = { 1.1, 1.1, 3.3, 3.3, 1.1 };
 
     df.load_data(std::move(idxvec), 
                  std::make_pair("dbl_col1", dblvec1),
                  std::make_pair("dbl_col2", dblvec2),
                  std::make_pair("dbl_col3", dblvec3),
                  std::make_pair("dbl_col4", dblvec4),
-                 std::make_pair("dbl_col5", dblvec5));
+                 std::make_pair("dbl_col5", dblvec5),
+                 std::make_pair("dbl_col6", dblvec6));
 
     typedef DataFrameView<unsigned long> MyDataFrameView;
 
     MyDataFrameView dfv = 
-        df.get_view_by_idx<double>(Index2D<unsigned long> { 3, 5 });
+        df.get_view_by_idx<double>(Index2D<unsigned long> { 2, 4 });
+    assert(dfv.get_index().size() == 3);
     MeanVisitor<double> mean_visitor;
     assert(abs(dfv.visit<double>("dbl_col1", 
-                                 mean_visitor).get_result() - 4.4) < 0.00001);
+                                 mean_visitor).get_result() - 3.3) < 0.00001);
 
     DotProdVisitor<double> dp_visitor;
     assert(abs(dfv.visit<double, double>("dbl_col1", "dbl_col2", 
-                                 dp_visitor).get_result() - 75.02) < 0.00001);
+                                 dp_visitor).get_result() - 45.98) < 0.00001);
+
+    
+    SimpleRollAdopter<MeanVisitor<double>, double> 
+        mean_roller1(MeanVisitor<double>(), 3);
+    const auto &res_sra = 
+        dfv.single_act_visit<double>("dbl_col1", mean_roller1).get_result();
+    assert(abs(res_sra[2] - 3.3) < 0.00001);
+
+    CumSumVisitor<double> cs_visitor;
+    const auto &res_cs =
+        dfv.single_act_visit<double>("dbl_col1", cs_visitor).get_result();
+    assert(abs(res_cs[0] - 2.2) < 0.00001);
+    assert(abs(res_cs[1] - 5.5) < 0.00001);
+    assert(abs(res_cs[2] - 9.9) < 0.00001);
+
+    CumProdVisitor<double> cp_visitor;
+    const auto &res_cp =
+        dfv.single_act_visit<double>("dbl_col1", cp_visitor).get_result();
+    assert(abs(res_cp[0] - 2.2) < 0.00001);
+    assert(abs(res_cp[1] - 7.26) < 0.00001);
+    assert(abs(res_cp[2] - 31.944) < 0.00001);
+
+    CumMinVisitor<double> cmin_visitor;
+    const auto &res_cmin =
+        dfv.single_act_visit<double>("dbl_col1", cmin_visitor).get_result();
+    assert(abs(res_cmin[0] - 2.2) < 0.00001);
+    assert(abs(res_cmin[1] - 2.2) < 0.00001);
+    assert(abs(res_cmin[2] - 2.2) < 0.00001);
+
+    CumMaxVisitor<double> cmax_visitor;
+    const auto &res_cmax =
+        dfv.single_act_visit<double>("dbl_col1", cmax_visitor).get_result();
+    assert(abs(res_cmax[0] - 2.2) < 0.00001);
+    assert(abs(res_cmax[1] - 3.3) < 0.00001);
+    assert(abs(res_cmax[2] - 4.4) < 0.00001);
+
+    MyDataFrameView dfv2 = 
+        df.get_view_by_idx<double>(Index2D<unsigned long> { 2, 9 });
+
+    AutoCorrVisitor<double> ac_visitor;
+    const auto &res_ac =
+        dfv2.single_act_visit<double>("dbl_col5", ac_visitor).get_result();
+    assert(abs(res_ac[1] - -0.36855) < 0.00001);
+    assert(abs(res_ac[5] - 0.67957) < 0.00001);
+
+    ReturnVisitor<double> ret_visitor(return_policy::monetary);
+    const auto &res_ret =
+        df.single_act_visit<double>("dbl_col4", ret_visitor).get_result();
+    assert(abs(res_ret[0] - -1.5) < 0.00001);
+    assert(abs(res_ret[6] - 0.3) < 0.00001);
+
+    MedianVisitor<double> med_visitor;
+    const auto &res_med =
+        dfv2.single_act_visit<double>("dbl_col3", med_visitor).get_result();
+    assert(abs(res_med - 4.95) < 0.00001);
+
+    ModeVisitor<2, double> mode_visitor;
+    const auto &res_mode =
+        dfv2.single_act_visit<double>("dbl_col6", mode_visitor).get_result();
+    assert(abs(res_mode[1].value - 3.3) < 0.00001);
+
+    DiffVisitor<double> diff_visitor(1);
+    const auto &res_diff =
+        dfv.single_act_visit<double>("dbl_col1", diff_visitor).get_result();
+    assert(res_diff.size() == 2);
+    assert(abs(res_diff[0] - 1.1) < 0.00001);
+    assert(abs(res_diff[1] - 1.1) < 0.00001);
+
+    ZScoreVisitor<double> zs_visitor;
+    const auto &res_zs =
+        dfv2.single_act_visit<double>("dbl_col5", zs_visitor).get_result();
+    assert(abs(res_zs[2] - -1.61418) < 0.00001);
+    assert(abs(res_zs[4] - 0.04336) < 0.00001);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes possible to use visitors on views.
Most of the changes consist in using generic templates instead of assuming a vector datatype. Many single action visitor are affected by this change.
Review and comments are welcome.