### PR TITLE
Change RNG to mt19937_64

### DIFF
--- a/include/DataFrame/Internals/RandGen.tcc
+++ b/include/DataFrame/Internals/RandGen.tcc
@@ -42,7 +42,7 @@ static inline std::vector<T>
 _gen_rand_(std::size_t n, const RandGenParams<T> &params, D &&dist)  {
 
     std::random_device  rd;
-    std::mt19937        gen(rd());
+    std::mt19937_64     gen(rd());
 
     if (params.seed != static_cast<unsigned int>(-1))  gen.seed(params.seed);
 


### PR DESCRIPTION
Creates a pretty substantial performance gain on 64 bit systems.
On a computer at work (i7-7700), previous results on the performance benchmark:
```
All memory allocations are done. Calculating means ...

real    4m47.221s
user    4m11.525s
sys     0m34.145s
```

mt19937_64:
```
All memory allocations are done. Calculating means ...

real    4m16.923s
user    3m41.817s
sys     0m31.185s
```