### PR TITLE
Fixed SIGFAULT 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ if (ENABLE_TESTING)
   add_executable(vector_ptr_view_tester test/vector_ptr_view_tester.cc)
   add_executable(date_time_tester  test/date_time_tester.cc)
   add_executable(gen_rand_tester  test/gen_rand_tester.cc)
+  add_executable(dataframe_thread_safety  test/dataframe_thread_safety.cc)
 
   # Link the DataFrame library to the test binary
   target_link_libraries(dataframe_tester DataFrame)
@@ -253,6 +254,9 @@ if (ENABLE_TESTING)
   # Link the DataFrame library to the test binary
   target_link_libraries(gen_rand_tester DataFrame)
 
+  # Link the DataFrame library to the test binary
+  target_link_libraries(dataframe_thread_safety DataFrame)
+
   if (UNIX)
     # Find pthreads library
     set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -264,6 +268,7 @@ if (ENABLE_TESTING)
     target_link_libraries(vector_ptr_view_tester Threads::Threads)
     target_link_libraries(date_time_tester Threads::Threads)
     target_link_libraries(gen_rand_tester Threads::Threads)
+    target_link_libraries(dataframe_thread_safety Threads::Threads)
   endif (UNIX)
 
   if (UNIX AND NOT APPLE)
@@ -274,6 +279,7 @@ if (ENABLE_TESTING)
     target_link_libraries(vector_ptr_view_tester rt)
     target_link_libraries(date_time_tester rt)
     target_link_libraries(gen_rand_tester rt)
+    target_link_libraries(dataframe_thread_safety rt)
   endif()
 
   # Enable ctest, testing so we can see if unit tests pass or fail in CI
@@ -304,6 +310,10 @@ if (ENABLE_TESTING)
   add_test(NAME gen_rand_tester
            COMMAND gen_rand_tester
            WORKING_DIRECTORY $<TARGET_FILE_DIR:gen_rand_tester>)
+
+  add_test(NAME dataframe_thread_safety
+           COMMAND dataframe_thread_safety
+           WORKING_DIRECTORY $<TARGET_FILE_DIR:dataframe_thread_safety>)
 
   message("-- Copying files for testing")
   # Ctest require this files in the build dir, on all platforms

--- a/include/DataFrame/DataFrame.h
+++ b/include/DataFrame/DataFrame.h
@@ -90,9 +90,6 @@ public:
     DataFrame &operator= (DataFrame &&) = default;
 
     ~DataFrame() {
-        column_list_.clear();
-        column_tb_.clear();
-        indices_.clear();
         const SpinGuard guard(lock_);
         data_.clear();
     };

--- a/include/DataFrame/DataFrame.h
+++ b/include/DataFrame/DataFrame.h
@@ -89,7 +89,13 @@ public:
     DataFrame &operator= (const DataFrame &) = default;
     DataFrame &operator= (DataFrame &&) = default;
 
-    ~DataFrame() = default;
+    ~DataFrame() {
+        column_list_.clear();
+        column_tb_.clear();
+        indices_.clear();
+        const SpinGuard guard(lock_);
+        data_.clear();
+    };
 
 private:
 

--- a/test/dataframe_thread_safety.cc
+++ b/test/dataframe_thread_safety.cc
@@ -1,0 +1,48 @@
+#include <DataFrame/DataFrame.h>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+
+using namespace hmdf;
+
+typedef StdDataFrame<unsigned long> MyDataFrame;
+
+static void test_thread_safety()
+{
+    constexpr size_t thread_count = 4;
+
+    std::cout << "Testing Thread safety ..." << std::endl;
+
+    SpinLock lock;
+    MyDataFrame::set_lock(&lock);
+    std::vector<std::thread> thr_vec;
+
+    std::cout << "* starting threads ..." << std::endl;
+    for (size_t i = 0; i < thread_count; ++i)
+        thr_vec.push_back(std::thread([]() {
+            constexpr size_t jobs_per_thread = 2500;
+            constexpr unsigned long vec_len = 100;
+            for (size_t j = 0; j < jobs_per_thread; ++j) {
+                MyDataFrame df;
+                std::vector<double> vec(vec_len);
+                std::iota(vec.begin(), vec.end(), 0);
+                df.load_index(MyDataFrame::gen_sequence_index(0, vec_len, 1));
+                df.load_column("abc", std::move(vec));
+            };
+        }));
+
+    std::cout << "* waiting for threads to collect results ..." << std::endl;
+    for (size_t i = 0; i < thread_count; ++i)
+        thr_vec[i].join();
+
+    MyDataFrame::remove_lock();
+}
+
+// ---- MAIN ---------------------------------------------------------------------
+
+int main(int argc, char *argv[]) {
+
+    test_thread_safety();
+    return (0);
+}


### PR DESCRIPTION
Fixed DataFrame SIGFAULT in multi-threaded setup on Linux.

Reason was a forgotten spin lock on DataFrame::data_ in DataFrame destructor which resulted in an unprotected access to `HeteroVector::vectors_`.

Added a test to verify, that it has fixed the problem.

I've seen the same pattern in HeteroView, but haven't created a test for it.
