### PR TITLE
Fixed clang warnings

### DIFF
--- a/include/DataFrame/Internals/DataFrame.tcc
+++ b/include/DataFrame/Internals/DataFrame.tcc
@@ -1518,7 +1518,6 @@ transpose(IndexVecType &&indices, const V &new_col_names) const  {
 
     std::vector<std::vector<T>> trans_cols(indices_.size());
     DataFrame                   df;
-    size_type                   idx = 0;
 
     for (size_type i = 0; i < indices_.size(); ++i)  {
         trans_cols[i].reserve(num_cols);

--- a/include/DataFrame/Internals/DataFrame_join.tcc
+++ b/include/DataFrame/Internals/DataFrame_join.tcc
@@ -249,8 +249,8 @@ column_join_helper_(const LHS_T &lhs,
 
     // Load the new result index
     result.load_index(
-        std::move(StdDataFrame<unsigned int>::gen_sequence_index(
-               0, static_cast<unsigned int>(jii_s), 1)));
+        StdDataFrame<unsigned int>::gen_sequence_index(
+               0, static_cast<unsigned int>(jii_s), 1));
 
     // Load the lhs and rhs indices into two columns in the result
     // Also load the unified named column

--- a/include/DataFrame/Internals/DataFrame_set.tcc
+++ b/include/DataFrame/Internals/DataFrame_set.tcc
@@ -701,7 +701,6 @@ void DataFrame<I, H>::remove_data_by_sel (const char *name, F &sel_functor)  {
                   "Only a StdDataFrame can call remove_data_by_loc()");
 
     const ColumnVecType<T>  &vec = get_column<T>(name);
-    const size_type         idx_s = indices_.size();
     const size_type         col_s = vec.size();
     std::vector<size_type>  col_indices;
 

--- a/include/DataFrame/Utils/FixedSizeString.h
+++ b/include/DataFrame/Utils/FixedSizeString.h
@@ -171,8 +171,6 @@ public:
     inline size_type
     find (const VirtualString &token, size_type pos = 0) const noexcept  {
 
-        const size_type len = size ();
-
         return (find (token.c_str (), pos));
     }
 

--- a/test/dataframe_tester_2.cc
+++ b/test/dataframe_tester_2.cc
@@ -1423,7 +1423,7 @@ static void test_HurstExponentVisitor()  {
 
     MyDataFrame df;
 
-    df.load_index(std::move(MyDataFrame::gen_sequence_index(0, 1024, 1)));
+    df.load_index(MyDataFrame::gen_sequence_index(0, 1024, 1));
     df.load_column("d1_col", std::move(d1), nan_policy::dont_pad_with_nans);
     df.load_column("d2_col", std::move(d2), nan_policy::dont_pad_with_nans);
     df.load_column("d3_col", std::move(d3), nan_policy::dont_pad_with_nans);
@@ -1922,7 +1922,7 @@ static void test_DecomposeVisitor()  {
         };
     MyDataFrame                 df;
 
-    df.load_data(std::move(MyDataFrame::gen_sequence_index(0, y_vec.size(), 1)),
+    df.load_data(MyDataFrame::gen_sequence_index(0, y_vec.size(), 1),
                  std::make_pair("IBM_closes", y_vec));
 
     DecomposeVisitor<double>    d_v (7, 0.6, 0.01);


### PR DESCRIPTION
Hi, one more PR from me. I'm using clang for compiling the library and I enable all warnings with -Wall.
The compiler complains about two things 1. unused variables, 2. incorrect std::move calls ...

As for the unused variables [-Wunused-variable]:
a) They are mainly a problem in tests because the compiler doesn't see the variables used within asserts. A proper solution could be using the `[[maybe_unused]]` attribute, but it's ugly, so I left tests untouched and the decision is purely on you ;-)
b) There were few occurrences in the rest of the code, so I fixed those.

As for the incorrect std::move [-Wpessimizing-move]:
According to the spec std::move should not be called on temporary objects and local variables returned from functions, so I fixed the warnings. More details can be found e.g. in:
  - [When not to std::move](https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c/)
  - [Copy Elision](https://en.cppreference.com/w/cpp/language/copy_elision)

Hope you find this useful.

And thanks for the lib, it's awesome!
