### PR TITLE
Fix cmake target name repetition error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,8 +221,10 @@ if (MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /wd4251")
 endif(MSVC)
 
-# Add the uninstall target
-include(AddUninstallTarget)
+# Add the uninstall target if its not defined
+if(NOT TARGET uninstall)
+  include(AddUninstallTarget)
+endif()
 
 if (ENABLE_TESTING)
   # Build the test binary


### PR DESCRIPTION
Simple check to define the uninstall target only if its not already defined.
This solves a target name repetition error that occurs when compiling this project along other projects that also use the uninstall target.