### PR TITLE
Fixed compile of other projects using DataFrame with Visual Studio 2019 when HMDF_SHARED is not defined

### DIFF
--- a/include/DataFrame/Utils/DateTime.h
+++ b/include/DataFrame/Utils/DateTime.h
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(_WIN32) || defined(_WIN64)
 #  include <windows.h>
-#  ifdef _MSC_VER
+#  if defined(_MSC_VER) && defined(HMDF_SHARED)
 #    ifdef LIBRARY_EXPORTS
 #      define LIBRARY_API __declspec(dllexport)
 #    else

--- a/include/DataFrame/Utils/FixedSizeString.h
+++ b/include/DataFrame/Utils/FixedSizeString.h
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 
 #if defined(_WIN32) || defined(_WIN64)
-#  ifdef _MSC_VER
+#  if defined(_MSC_VER) && defined(HMDF_SHARED)
 #    ifdef LIBRARY_EXPORTS
 #      define LIBRARY_API __declspec(dllexport)
 #    else

--- a/include/DataFrame/Utils/ThreadGranularity.h
+++ b/include/DataFrame/Utils/ThreadGranularity.h
@@ -35,7 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #if defined(_WIN32) || defined(_WIN64)
-#  ifdef _MSC_VER
+#  if defined(_MSC_VER) && defined(HMDF_SHARED)
 #    ifdef LIBRARY_EXPORTS
 #      define LIBRARY_API __declspec(dllexport)
 #    else

--- a/include/DataFrame/Vectors/VectorPtrView.h
+++ b/include/DataFrame/Vectors/VectorPtrView.h
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iterator>
 #include <vector>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && defined(HMDF_SHARED)
 #  ifdef LIBRARY_EXPORTS
 #    define LIBRARY_API __declspec(dllexport)
 #  else

--- a/include/DataFrame/Vectors/VectorView.h
+++ b/include/DataFrame/Vectors/VectorView.h
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iterator>
 #include <vector>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && defined(HMDF_SHARED)
 #  ifdef LIBRARY_EXPORTS
 #    define LIBRARY_API __declspec(dllexport)
 #  else


### PR DESCRIPTION
If HMDF_SHARED is not defined, dllexport and dllimport must not be used