### PR TITLE
Add missing includes & avoid to include windows.h in public interface

### DIFF
--- a/include/DataFrame/DataFrame.h
+++ b/include/DataFrame/DataFrame.h
@@ -38,10 +38,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <functional>
 #include <future>
-#include <iostream>
-#include <map>
 #include <tuple>
+#include <type_traits>
 #include <typeindex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/DataFrameFinancialVisitors.h
+++ b/include/DataFrame/DataFrameFinancialVisitors.h
@@ -33,11 +33,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/DataFrameTypes.h>
 
 #include <algorithm>
-
+#include <cmath>
 #include <functional>
+#include <future>
 #include <iterator>
 #include <limits>
 #include <numeric>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 // ----------------------------------------------------------------------------

--- a/include/DataFrame/DataFrameMLVisitors.h
+++ b/include/DataFrame/DataFrameMLVisitors.h
@@ -34,10 +34,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Vectors/VectorPtrView.h>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <complex>
 #include <functional>
-#include <iterator>
+#include <limits>
+#include <random>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/DataFrameOperators.h
+++ b/include/DataFrame/DataFrameOperators.h
@@ -29,7 +29,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <algorithm>
 // #include <execution>
+#include <functional>
+#include <iterator>
+#include <utility>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/DataFrameOperators.h
+++ b/include/DataFrame/DataFrameOperators.h
@@ -40,15 +40,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace hmdf
 {
 
-#ifdef _MSC_VER
-#  ifdef min
-#    undef min
-#  endif // min
-#  ifdef max
-#    undef max
-#  endif // max
-#endif // _MSC_VER
-
 // Both lhs and rhs must be already sorted by index, otherwise the result
 // is nonsensical.
 //

--- a/include/DataFrame/DataFrameStatsVisitors.h
+++ b/include/DataFrame/DataFrameStatsVisitors.h
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Utils/Utils.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 
 #include <cmath>
@@ -47,9 +48,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 #include <future>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <numeric>
+#include <type_traits>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/DataFrameTransformVisitors.h
+++ b/include/DataFrame/DataFrameTransformVisitors.h
@@ -32,8 +32,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/DataFrameStatsVisitors.h>
 #include <DataFrame/DataFrameTypes.h>
 
+#include <algorithm>
 #include <cassert>
+#include <cmath>
+#include <iterator>
+#include <limits>
 #include <type_traits>
+#include <vector>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/DataFrameTypes.h
+++ b/include/DataFrame/DataFrameTypes.h
@@ -31,12 +31,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <DataFrame/Vectors/HeteroVector.h>
 
-#include <cmath>
 #include <complex>
 #include <limits>
 #include <stdexcept>
 #include <tuple>
-#include <type_traits>
+#include <vector>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/DataFrameTypes.h
+++ b/include/DataFrame/DataFrameTypes.h
@@ -42,15 +42,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace hmdf
 {
 
-#if defined(_WIN32) || defined(_WIN64)
-#  ifdef min
-#    undef min
-#  endif // min
-#  ifdef max
-#    undef max
-#  endif // max
-#endif // _WIN32 || _WIN64
-
 // ----------------------------------------------------------------------------
 
 // Generic DataFrame error

--- a/include/DataFrame/Utils/Aggregenerator.h
+++ b/include/DataFrame/Utils/Aggregenerator.h
@@ -29,9 +29,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include <cassert>
 #include <iterator>
 #include <tuple>
+#include <utility>
 
 #if defined(_WIN32) && defined(HMDF_SHARED)
 #  ifdef LIBRARY_EXPORTS

--- a/include/DataFrame/Utils/DateTime.h
+++ b/include/DataFrame/Utils/DateTime.h
@@ -29,17 +29,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include <cstdio>
-#include <ctime>
-#include <functional>
 #include <limits>
-#include <stdexcept>
 #include <string>
-#include <sys/timeb.h>
 #include <time.h>
 
 #if defined(_WIN32) || defined(_WIN64)
-#  include <windows.h>
 #  if defined(_MSC_VER) && defined(HMDF_SHARED)
 #    ifdef LIBRARY_EXPORTS
 #      define LIBRARY_API __declspec(dllexport)
@@ -49,12 +43,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  else
 #    define LIBRARY_API
 #  endif // _MSC_VER
-#  ifdef min
-#    undef min
-#  endif // min
-#  ifdef max
-#    undef max
-#  endif // max
 #else
 #  define LIBRARY_API
 #endif // _WIN32 || _WIN64

--- a/include/DataFrame/Utils/DateTime.h
+++ b/include/DataFrame/Utils/DateTime.h
@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <DataFrame/DataFrameExports.h>
+
 #include <limits>
 #include <string>
 #include <time.h>

--- a/include/DataFrame/Utils/FixedSizePriorityQueue.h
+++ b/include/DataFrame/Utils/FixedSizePriorityQueue.h
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <array>
 #include <functional>
 #include <iterator>
+#include <utility>
 #include <vector>
 
 #if defined(_WIN32) && defined(HMDF_SHARED)

--- a/include/DataFrame/Utils/FixedSizeString.h
+++ b/include/DataFrame/Utils/FixedSizeString.h
@@ -31,10 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdarg>
 #include <cstdio>
-#include <cstdlib>
+#include <cstring>
 #include <functional>
-#include <iostream>
-#include <string.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 #  if defined(_MSC_VER) && defined(HMDF_SHARED)

--- a/include/DataFrame/Utils/ThreadGranularity.h
+++ b/include/DataFrame/Utils/ThreadGranularity.h
@@ -44,12 +44,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  else
 #    define LIBRARY_API
 #  endif // _MSC_VER
-#  ifdef min
-#    undef min
-#  endif // min
-#  ifdef max
-#    undef max
-#  endif // max
 #else
 #  define LIBRARY_API
 #endif // _WIN32 || _WIN64

--- a/include/DataFrame/Vectors/HeteroPtrView.h
+++ b/include/DataFrame/Vectors/HeteroPtrView.h
@@ -34,7 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 #include <type_traits>
 #include <unordered_map>
-#include <type_traits>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/Vectors/HeteroPtrView.h
+++ b/include/DataFrame/Vectors/HeteroPtrView.h
@@ -32,7 +32,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Vectors/VectorPtrView.h>
 
 #include <functional>
+#include <type_traits>
 #include <unordered_map>
+#include <type_traits>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/Vectors/HeteroPtrView.tcc
+++ b/include/DataFrame/Vectors/HeteroPtrView.tcc
@@ -28,6 +28,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <algorithm>
+#include <stdexcept>
+#include <utility>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/Vectors/HeteroVector.h
+++ b/include/DataFrame/Vectors/HeteroVector.h
@@ -32,7 +32,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Vectors/HeteroPtrView.h>
 #include <DataFrame/Vectors/HeteroView.h>
 
+#include <functional>
+#include <type_traits>
 #include <unordered_map>
+#include <vector>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/Vectors/HeteroVector.tcc
+++ b/include/DataFrame/Vectors/HeteroVector.tcc
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Vectors/HeteroVector.h>
 
 #include <algorithm>
+#include <utility>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/Vectors/HeteroView.h
+++ b/include/DataFrame/Vectors/HeteroView.h
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Vectors/VectorView.h>
 
 #include <functional>
+#include <type_traits>
 #include <unordered_map>
 
 // ----------------------------------------------------------------------------

--- a/include/DataFrame/Vectors/HeteroView.tcc
+++ b/include/DataFrame/Vectors/HeteroView.tcc
@@ -30,6 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Vectors/HeteroVector.h>
 
 #include <algorithm>
+#include <stdexcept>
+#include <utility>
 
 // ----------------------------------------------------------------------------
 

--- a/include/DataFrame/Vectors/VectorView.h
+++ b/include/DataFrame/Vectors/VectorView.h
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <iterator>
+#include <utility>
 #include <vector>
 
 #if defined(_MSC_VER) && defined(HMDF_SHARED)

--- a/src/Utils/DateTime.cc
+++ b/src/Utils/DateTime.cc
@@ -30,7 +30,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/Utils/DateTime.h>
 #include <DataFrame/Utils/FixedSizeString.h>
 
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+
 #ifdef _MSC_VER
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
 #  ifdef _MSC_EXTENSIONS
 #    define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
 #  else

--- a/src/Utils/DateTime.cc
+++ b/src/Utils/DateTime.cc
@@ -35,7 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstring>
 #include <stdexcept>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
 #  ifdef _MSC_EXTENSIONS
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  endif // _MSC_EXTENSIONS
 #else
 #  include <sys/time.h>
-#endif // _MSC_VER
+#endif // _WIN32
 
 // ----------------------------------------------------------------------------
 
@@ -54,7 +54,7 @@ namespace hmdf
 
 DateTime::DateTime (DT_TIME_ZONE tz) : time_zone_(tz)  {
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     FILETIME            ft;
     unsigned __int64    tmpres = 0;
 
@@ -81,7 +81,7 @@ DateTime::DateTime (DT_TIME_ZONE tz) : time_zone_(tz)  {
 
     ::gettimeofday(&tv, nullptr);
     set_time(tv.tv_sec, tv.tv_usec * 1000);
-#endif // _MSC_VER
+#endif // _WIN32
 }
 
 // ----------------------------------------------------------------------------
@@ -909,14 +909,14 @@ std::string DateTime::string_format (DT_FORMAT format) const  {
 inline void DateTime::change_env_timezone_(DT_TIME_ZONE time_zone)  {
 
     if (time_zone != DT_TIME_ZONE::LOCAL)  {
-#ifdef _MSC_VER
+#ifdef _WIN32
         // SetEnvironmentVariable (L"TZ", TIMEZONES_ [time_zone]);
         _putenv (TIMEZONES_[static_cast<int>(time_zone)]);
         _tzset ();
 #else
         ::setenv ("TZ", TIMEZONES_[static_cast<int>(time_zone)], 1);
         ::tzset ();
-#endif // _MSC_VER
+#endif // _WIN32
     }
 }
 
@@ -925,14 +925,14 @@ inline void DateTime::change_env_timezone_(DT_TIME_ZONE time_zone)  {
 inline void DateTime::reset_env_timezone_(DT_TIME_ZONE time_zone)  {
 
     if (time_zone != DT_TIME_ZONE::LOCAL)  {
-#ifdef _MSC_VER
+#ifdef _WIN32
         // SetEnvironmentVariable (L"TZ", nullptr);
         _putenv ("TZ=");
         _tzset ();
 #else
         ::unsetenv ("TZ");
         ::tzset ();
-#endif // _MSC_VER
+#endif // _WIN32
     }
 }
 
@@ -965,11 +965,11 @@ DateTime::breaktime_ (EpochType the_time, NanosecondType nanosec) noexcept  {
 
     struct tm   ltime;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     localtime_s (&ltime, &the_time);
 #else
     localtime_r (&the_time, &ltime);
-#endif // _MSC_VER
+#endif // _WIN32
 
     reset_env_timezone_(time_zone_);
 

--- a/src/Vectors/HeteroPtrView.cc
+++ b/src/Vectors/HeteroPtrView.cc
@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <DataFrame/Vectors/HeteroPtrView.h>
 
+#include <utility>
+
 // ----------------------------------------------------------------------------
 
 namespace hmdf

--- a/src/Vectors/HeteroVector.cc
+++ b/src/Vectors/HeteroVector.cc
@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <DataFrame/Vectors/HeteroVector.h>
 
+#include <utility>
+
 // ----------------------------------------------------------------------------
 
 namespace hmdf

--- a/src/Vectors/HeteroView.cc
+++ b/src/Vectors/HeteroView.cc
@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <DataFrame/Vectors/HeteroView.h>
 
+#include <utility>
+
 // ----------------------------------------------------------------------------
 
 namespace hmdf


### PR DESCRIPTION
- Inclusion of `windows.h` is moved to `DateTime.cc` compilation unit so that it doesn't leak in public interface, since this header is just pure evil.
- fix compilation of `DateTime.cc` with MinGW (logic is windows specific, not Visual Studio specific)
- Some inclusion cleanup in other files.