### PR TITLE
CMake: prefer compile feature to set at least C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.8)
 project (DataFrame VERSION 1.0.0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # Produce cmpile_commands.json
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(ENABLE_TESTING "Enable testing" ON)
 
@@ -34,15 +31,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY
 #   create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
 #
 ## set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-# Disable C and C++ compiler extensions. C/CXX_EXTENSIONS are ON by default to
-# allow the compilers to use extended variants of the C/CXX language. However,
-# this could expose cross-platform bugs in user code or in the headers of
-# third-party dependencies and thus it is strongly suggested to turn
-# extensions off.
-#
-set(CMAKE_C_EXTENSIONS OFF)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Enable RPATH support for installed binaries and libraries
 #
@@ -120,12 +108,14 @@ set(${LIBRARY_TARGET_NAME}_HDR
 #
 if (UNIX)
     add_library(${LIBRARY_TARGET_NAME} ${${LIBRARY_TARGET_NAME}_SRC})
+    target_compile_features(${LIBRARY_TARGET_NAME} PUBLIC cxx_std_17)
 endif(UNIX)
 
 if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     add_definitions(-D_USE_MATH_DEFINES)
     add_library(${LIBRARY_TARGET_NAME} ${${LIBRARY_TARGET_NAME}_SRC})
+    target_compile_features(${LIBRARY_TARGET_NAME} PUBLIC cxx_std_17)
 
     # If shared:
         # At build time: LIBRARY_EXPORTS and HMDF_SHARED defined
@@ -138,6 +128,7 @@ endif(MSVC)
 
 if (MINGW)
     add_library(${LIBRARY_TARGET_NAME} ${${LIBRARY_TARGET_NAME}_SRC})
+    target_compile_features(${LIBRARY_TARGET_NAME} PUBLIC cxx_std_17)
 endif()
 
 # Set two minimum target properties for the library.


### PR DESCRIPTION
Good practice in a C++ library is to use `target_compile_feature()` to set minimum C++ standard, in order to not constrain a specific maximum standard like `CXX_STANDARD` does.

I've also removed PIC.
In CMake, PIC comes for free in shared lib. For static lib, it's a user decision, so it's better to keep default behavior (principle of least surprise).