### PR TITLE
Fix the tests to really check the assertions in Release mode

### DIFF
--- a/test/dataframe_tester.cc
+++ b/test/dataframe_tester.cc
@@ -25,6 +25,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/DataFrame.h>
 #include <DataFrame/DataFrameFinancialVisitors.h>
 #include <DataFrame/DataFrameMLVisitors.h>
@@ -32,7 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/DataFrameStatsVisitors.h>
 #include <DataFrame/RandGen.h>
 
-#include <cassert>
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/test/dataframe_tester_2.cc
+++ b/test/dataframe_tester_2.cc
@@ -24,6 +24,12 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/DataFrame.h>
 #include <DataFrame/DataFrameFinancialVisitors.h>
 #include <DataFrame/DataFrameMLVisitors.h>
@@ -31,7 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/DataFrameTransformVisitors.h>
 #include <DataFrame/RandGen.h>
 
-#include <cassert>
 #include <iostream>
 #include <string>
 

--- a/test/dataframe_tester_3.cc
+++ b/test/dataframe_tester_3.cc
@@ -24,6 +24,12 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/DataFrame.h>
 #include <DataFrame/DataFrameFinancialVisitors.h>
 #include <DataFrame/DataFrameMLVisitors.h>
@@ -31,7 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <DataFrame/DataFrameTransformVisitors.h>
 #include <DataFrame/RandGen.h>
 
-#include <cassert>
 #include <iostream>
 #include <string>
 

--- a/test/dataframe_thread_safety.cc
+++ b/test/dataframe_thread_safety.cc
@@ -1,6 +1,10 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/DataFrame.h>
 
-#include <cassert>
 #include <iostream>
 #include <string>
 

--- a/test/date_time_tester.cc
+++ b/test/date_time_tester.cc
@@ -27,11 +27,15 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/Utils/DateTime.h>
 #include <DataFrame/Utils/FixedSizePriorityQueue.h>
 #include <DataFrame/Utils/FixedSizeString.h>
 
-#include <cassert>
 #include <cstdlib>
 #include <iostream>
 #include <string>

--- a/test/gen_rand_tester.cc
+++ b/test/gen_rand_tester.cc
@@ -25,9 +25,13 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/RandGen.h>
 
-#include <cassert>
 #include <iostream>
 
 using namespace hmdf;

--- a/test/vector_ptr_view_tester.cc
+++ b/test/vector_ptr_view_tester.cc
@@ -27,9 +27,13 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/Vectors/VectorPtrView.h>
 
-#include <cassert>
 #include <iostream>
 
 using namespace hmdf;

--- a/test/vectors_tester.cc
+++ b/test/vectors_tester.cc
@@ -25,9 +25,13 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
 #include <DataFrame/Vectors/HeteroVector.h>
 
-#include <cassert>
 #include <iostream>
 #include <string>
 #include <typeinfo>


### PR DESCRIPTION
Current tests are based on assert, which is no-op in Release mode since NDEBUG definition is injected.
CI files run the build in Release mode, so it doesn't really test the library, except that lib & program are able to compile, link and run.