### PR TITLE
CMake: inject HMDF_HAVE_CLOCK_GETTIME definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ target_sources(DataFrame
 
 target_compile_features(DataFrame PUBLIC cxx_std_17)
 target_compile_definitions(DataFrame
+    PRIVATE
+        $<$<BOOL:${HMDF_HAVE_CLOCK_GETTIME}>:HMDF_HAVE_CLOCK_GETTIME>
     PUBLIC
         $<$<CXX_COMPILER_ID:MSVC>:_USE_MATH_DEFINES>
 )


### PR DESCRIPTION
`HMDF_HAVE_CLOCK_GETTIME` definition is not injected currently.

`check_symbol_exists(clock_gettime "time.h" HMDF_HAVE_CLOCK_GETTIME)` only set CMake variable `HMDF_HAVE_CLOCK_GETTIME` to 1 or 0, but it doesn't mean that a definition with the same name is magically injected during build of DataFrame.