### PR TITLE
Do not export symbols which are templates since 2.0.0

### DIFF
--- a/include/DataFrame/Vectors/HeteroConstPtrView.h
+++ b/include/DataFrame/Vectors/HeteroConstPtrView.h
@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <DataFrame/Vectors/VectorPtrView.h>
-#include <DataFrame/DataFrameExports.h>
 
 #include <functional>
 #include <new>
@@ -49,7 +48,7 @@ struct  HeteroConstPtrView {
 
     using size_type = size_t;
 
-    HMDF_API HeteroConstPtrView();
+    HeteroConstPtrView();
     template<typename T>
     HeteroConstPtrView(const T *begin_ptr, const T *end_ptr);
 
@@ -69,13 +68,13 @@ struct  HeteroConstPtrView {
     HeteroConstPtrView(VectorConstPtrView<T, A> &vec);
     template<typename T>
     HeteroConstPtrView(VectorConstPtrView<T, A> &&vec);
-    HMDF_API HeteroConstPtrView(const HeteroConstPtrView &that);
-    HMDF_API HeteroConstPtrView(HeteroConstPtrView &&that);
+    HeteroConstPtrView(const HeteroConstPtrView &that);
+    HeteroConstPtrView(HeteroConstPtrView &&that);
 
     ~HeteroConstPtrView() { clear(); }
 
-    HMDF_API HeteroConstPtrView &operator= (const HeteroConstPtrView &rhs);
-    HMDF_API HeteroConstPtrView &operator= (HeteroConstPtrView &&rhs);
+    HeteroConstPtrView &operator= (const HeteroConstPtrView &rhs);
+    HeteroConstPtrView &operator= (HeteroConstPtrView &&rhs);
 
     template<typename T>
     VectorConstPtrView<T, A> &get_vector();
@@ -86,7 +85,7 @@ struct  HeteroConstPtrView {
     typename VectorConstPtrView<T, A>::size_type
     size () const { return (get_vector<T>().size()); }
 
-    HMDF_API void clear();
+    void clear();
 
     template<typename T>
     bool empty() const noexcept;

--- a/include/DataFrame/Vectors/HeteroConstView.h
+++ b/include/DataFrame/Vectors/HeteroConstView.h
@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <DataFrame/Vectors/VectorView.h>
-#include <DataFrame/DataFrameExports.h>
 
 #include <functional>
 #include <type_traits>
@@ -48,7 +47,7 @@ struct HeteroConstView  {
 
     using size_type = size_t;
 
-    HMDF_API HeteroConstView();
+    HeteroConstView();
     template<typename T>
     HeteroConstView(const T *begin_ptr, const T *end_ptr);
 
@@ -65,13 +64,13 @@ struct HeteroConstView  {
     template<typename T>
     void set_begin_end_special(const T *bp, const T *ep_1);
 
-    HMDF_API HeteroConstView(const HeteroConstView &that);
-    HMDF_API HeteroConstView(HeteroConstView &&that);
+    HeteroConstView(const HeteroConstView &that);
+    HeteroConstView(HeteroConstView &&that);
 
     ~HeteroConstView() { clear(); }
 
-    HMDF_API HeteroConstView &operator= (const HeteroConstView &rhs);
-    HMDF_API HeteroConstView &operator= (HeteroConstView &&rhs);
+    HeteroConstView &operator= (const HeteroConstView &rhs);
+    HeteroConstView &operator= (HeteroConstView &&rhs);
 
     template<typename T>
     VectorConstView<T, A> &get_vector();
@@ -82,7 +81,7 @@ struct HeteroConstView  {
     typename VectorConstView<T, A>::size_type
     size () const { return (get_vector<T>().size()); }
 
-    HMDF_API void clear();
+    void clear();
 
     template<typename T>
     bool empty() const noexcept;

--- a/include/DataFrame/Vectors/HeteroPtrView.h
+++ b/include/DataFrame/Vectors/HeteroPtrView.h
@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <DataFrame/Vectors/VectorPtrView.h>
-#include <DataFrame/DataFrameExports.h>
 
 #include <functional>
 #include <new>
@@ -49,7 +48,7 @@ struct HeteroPtrView {
 
     using size_type = size_t;
 
-    HMDF_API HeteroPtrView();
+    HeteroPtrView();
     template<typename T>
     HeteroPtrView(T *begin_ptr, T *end_ptr);
 
@@ -69,13 +68,13 @@ struct HeteroPtrView {
     HeteroPtrView(VectorPtrView<T, A> &vec);
     template<typename T>
     HeteroPtrView(VectorPtrView<T, A> &&vec);
-    HMDF_API HeteroPtrView(const HeteroPtrView &that);
-    HMDF_API HeteroPtrView(HeteroPtrView &&that);
+    HeteroPtrView(const HeteroPtrView &that);
+    HeteroPtrView(HeteroPtrView &&that);
 
     ~HeteroPtrView() { clear(); }
 
-    HMDF_API HeteroPtrView &operator= (const HeteroPtrView &rhs);
-    HMDF_API HeteroPtrView &operator= (HeteroPtrView &&rhs);
+    HeteroPtrView &operator= (const HeteroPtrView &rhs);
+    HeteroPtrView &operator= (HeteroPtrView &&rhs);
 
     template<typename T>
     VectorPtrView<T, A> &get_vector();
@@ -91,7 +90,7 @@ struct HeteroPtrView {
     typename VectorPtrView<T, A>::
     size_type size () const { return (get_vector<T>().size()); }
 
-    HMDF_API void clear();
+    void clear();
 
     template<typename T>
     bool empty() const noexcept;

--- a/include/DataFrame/Vectors/HeteroVector.h
+++ b/include/DataFrame/Vectors/HeteroVector.h
@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include <DataFrame/DataFrameExports.h>
 #include <DataFrame/Utils/AlignedAllocator.h>
 #include <DataFrame/Vectors/HeteroConstPtrView.h>
 #include <DataFrame/Vectors/HeteroConstView.h>
@@ -58,14 +57,14 @@ struct HeteroVector  {
 
     using size_type = size_t;
 
-    HMDF_API HeteroVector();
-    HMDF_API HeteroVector(const HeteroVector &that);
-    HMDF_API HeteroVector(HeteroVector &&that);
+    HeteroVector();
+    HeteroVector(const HeteroVector &that);
+    HeteroVector(HeteroVector &&that);
 
     ~HeteroVector() { clear(); }
 
-    HMDF_API HeteroVector &operator= (const HeteroVector &rhs);
-    HMDF_API HeteroVector &operator= (HeteroVector &&rhs);
+    HeteroVector &operator= (const HeteroVector &rhs);
+    HeteroVector &operator= (HeteroVector &&rhs);
 
     template<typename T>
     std::vector<T, typename allocator_declare<T, A>::type> &get_vector();
@@ -104,7 +103,7 @@ struct HeteroVector  {
     template<typename T>
     size_type size () const { return (get_vector<T>().size()); }
 
-    HMDF_API void clear();
+    void clear();
 
     template<typename T>
     void erase(size_type pos);

--- a/include/DataFrame/Vectors/HeteroView.h
+++ b/include/DataFrame/Vectors/HeteroView.h
@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <DataFrame/Vectors/VectorView.h>
-#include <DataFrame/DataFrameExports.h>
 
 #include <functional>
 #include <new>
@@ -49,7 +48,7 @@ struct HeteroView  {
 
     using size_type = size_t;
 
-    HMDF_API HeteroView();
+    HeteroView();
     template<typename T>
     HeteroView(T *begin_ptr, T *end_ptr);
 
@@ -65,13 +64,13 @@ struct HeteroView  {
     template<typename T>
     void set_begin_end_special(T *bp, T *ep_1);
 
-    HMDF_API HeteroView(const HeteroView &that);
-    HMDF_API HeteroView(HeteroView &&that);
+    HeteroView(const HeteroView &that);
+    HeteroView(HeteroView &&that);
 
     ~HeteroView() { clear(); }
 
-    HMDF_API HeteroView &operator= (const HeteroView &rhs);
-    HMDF_API HeteroView &operator= (HeteroView &&rhs);
+    HeteroView &operator= (const HeteroView &rhs);
+    HeteroView &operator= (HeteroView &&rhs);
 
     template<typename T>
     VectorView<T, A> &get_vector();
@@ -82,7 +81,7 @@ struct HeteroView  {
     typename VectorView<T, A>::
     size_type size () const { return (get_vector<T>().size()); }
 
-    HMDF_API void clear();
+    void clear();
 
     template<typename T>
     bool empty() const noexcept;


### PR DESCRIPTION
Some methods are templates since 2.0.0 but they still have `HMDF_API`. It breaks for Visual Studio if shared because it doesn't make sense to dllimport a template:

<details><summary>log</summary>

```
********************************************************************************
conan test cci-7e472d50\recipes\dataframe\all\test_package\conanfile.py dataframe/2.0.0@#577fae5085e2e62d4fd9e968316b382c -pr C:\J\w\prod\BuildSingleReference@4\207768\94eb937c-ddd4-41b8-9098-acad99486493/profile_windows_16_md_vs_release_64.dataframe-shared-True.txt -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
********************************************************************************
Configuration:
[settings]
arch=x86_64
build_type=Release
compiler=Visual Studio
compiler.runtime=MD
compiler.version=16
os=Windows
[options]
dataframe:shared=True
[build_requires]
[env]
[conf]
tools.system.package_manager:mode=install
tools.system.package_manager:sudo=True

dataframe/2.0.0 (test package): Installing package
Requirements
    dataframe/2.0.0 from local cache - Cache
Packages
    dataframe/2.0.0:127af201a4cdf8111e2e08540525c245c9b3b99e - Cache

Installing (downloading, building) binaries...
dataframe/2.0.0: Already installed!
dataframe/2.0.0 (test package): Generator txt created conanbuildinfo.txt
dataframe/2.0.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
dataframe/2.0.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
dataframe/2.0.0 (test package): Preset 'default' added to CMakePresets.json. Invoke it manually using 'cmake --preset default'
dataframe/2.0.0 (test package): If your CMake version is not compatible with CMakePresets (<3.19) call cmake like: 'cmake <path> -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE=C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\generators\conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW'
dataframe/2.0.0 (test package): Generator 'CMakeDeps' calling 'generate()'
dataframe/2.0.0 (test package): Aggregating env generators
dataframe/2.0.0 (test package): Generated conaninfo.txt
dataframe/2.0.0 (test package): Generated graphinfo
Using lockfile: 'C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\generators/conan.lock'
Using cached profile from lockfile
[HOOK - conan-center.py] pre_build(): [FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found
[HOOK - conan-center.py] pre_build(): [FPIC MANAGEMENT (KB-H007)] OK
dataframe/2.0.0 (test package): Calling build()
dataframe/2.0.0 (test package): CMake command: cmake -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_package/build/generators/conan_toolchain.cmake" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\."

----Running------
> cmake -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_package/build/generators/conan_toolchain.cmake" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\."
-----------------
-- Using Conan toolchain: C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_package/build/generators/conan_toolchain.cmake
-- The CXX compiler identification is MSVC 19.29.30147.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'DataFrame::DataFrame'
-- Configuring done
-- Generating done
-- Build files have been written to: C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_package/build
dataframe/2.0.0 (test package): CMake command: cmake --build "C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build" --config Release

----Running------
> cmake --build "C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build" --config Release
-----------------
Microsoft (R) Build Engine version 16.11.2+f32259642 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_package/CMakeLists.txt
  test_package.cpp
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(223,24): error C2491: 'hmdf::HeteroConstPtrView<A>::HeteroConstPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(226,24): error C2491: 'hmdf::HeteroConstPtrView<A>::HeteroConstPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(231,24): error C2491: 'hmdf::HeteroConstPtrView<A>::HeteroConstPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(239,1): error C2491: 'hmdf::HeteroConstPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(257,1): error C2491: 'hmdf::HeteroConstPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(274,29): error C2491: 'hmdf::HeteroConstPtrView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(212,21): error C2491: 'hmdf::HeteroConstView<A>::HeteroConstView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(216,1): error C2491: 'hmdf::HeteroConstView<A>::HeteroConstView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(218,21): error C2491: 'hmdf::HeteroConstView<A>::HeteroConstView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(224,1): error C2491: 'hmdf::HeteroConstView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(241,41): error C2491: 'hmdf::HeteroConstView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(258,26): error C2491: 'hmdf::HeteroConstView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(307,19): error C2491: 'hmdf::HeteroPtrView<A>::HeteroPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(310,19): error C2491: 'hmdf::HeteroPtrView<A>::HeteroPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(312,19): error C2491: 'hmdf::HeteroPtrView<A>::HeteroPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(317,37): error C2491: 'hmdf::HeteroPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(334,37): error C2491: 'hmdf::HeteroPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(351,24): error C2491: 'hmdf::HeteroPtrView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(322,16): error C2491: 'hmdf::HeteroView<A>::HeteroView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(325,16): error C2491: 'hmdf::HeteroView<A>::HeteroView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(327,16): error C2491: 'hmdf::HeteroView<A>::HeteroView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(332,31): error C2491: 'hmdf::HeteroView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(349,31): error C2491: 'hmdf::HeteroView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(366,21): error C2491: 'hmdf::HeteroView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(369,18): error C2491: 'hmdf::HeteroVector<A>::HeteroVector': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(379,18): error C2491: 'hmdf::HeteroVector<A>::HeteroVector': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(381,18): error C2491: 'hmdf::HeteroVector<A>::HeteroVector': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(386,35): error C2491: 'hmdf::HeteroVector<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(404,35): error C2491: 'hmdf::HeteroVector<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(422,23): error C2491: 'hmdf::HeteroVector<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Utils/FixedSizeString.h(87,11): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Utils/FixedSizeString.h(106,11): warning C4996: 'strcat': This function or variable may be unsafe. Consider using strcat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build\test_package.vcxproj]
dataframe/2.0.0 (test package): WARN: Using the new toolchains and generators without specifying a build profile (e.g: -pr:b=default) is discouraged and might cause failures and unexpected behavior
dataframe/2.0.0 (test package): WARN: Using the new toolchains and generators without specifying a build profile (e.g: -pr:b=default) is discouraged and might cause failures and unexpected behavior
ERROR: dataframe/2.0.0 (test package): Error in build() method, line 21
	cmake.build()
	ConanException: Error 1 while executing cmake --build "C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_package\build" --config Release
********************************************************************************
conan test cci-7e472d50\recipes\dataframe\all\test_v1_package\conanfile.py dataframe/2.0.0@#577fae5085e2e62d4fd9e968316b382c -pr C:\J\w\prod\BuildSingleReference@4\207768\94eb937c-ddd4-41b8-9098-acad99486493/profile_windows_16_md_vs_release_64.dataframe-shared-True.txt -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
********************************************************************************
Configuration:
[settings]
arch=x86_64
build_type=Release
compiler=Visual Studio
compiler.runtime=MD
compiler.version=16
os=Windows
[options]
dataframe:shared=True
[build_requires]
[env]
[conf]
tools.system.package_manager:mode=install
tools.system.package_manager:sudo=True

dataframe/2.0.0 (test package): Installing package
Requirements
    dataframe/2.0.0 from local cache - Cache
Packages
    dataframe/2.0.0:127af201a4cdf8111e2e08540525c245c9b3b99e - Cache

Installing (downloading, building) binaries...
dataframe/2.0.0: Already installed!
dataframe/2.0.0 (test package): Generator cmake created conanbuildinfo.cmake
dataframe/2.0.0 (test package): Generator cmake_find_package_multi created DataFrameConfigVersion.cmake
dataframe/2.0.0 (test package): Generator cmake_find_package_multi created DataFrameConfig.cmake
dataframe/2.0.0 (test package): Generator cmake_find_package_multi created DataFrameTargets.cmake
dataframe/2.0.0 (test package): Generator cmake_find_package_multi created DataFrameTarget-release.cmake
dataframe/2.0.0 (test package): Generator txt created conanbuildinfo.txt
dataframe/2.0.0 (test package): Aggregating env generators
dataframe/2.0.0 (test package): Generated conaninfo.txt
dataframe/2.0.0 (test package): Generated graphinfo
Using lockfile: 'C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f/conan.lock'
Using cached profile from lockfile
[HOOK - conan-center.py] pre_build(): [FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found
[HOOK - conan-center.py] pre_build(): [FPIC MANAGEMENT (KB-H007)] OK
dataframe/2.0.0 (test package): Calling build()

----Running------
> cd C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f && cmake -G "Visual Studio 16 2019" -A "x64" -DCONAN_LINK_RUNTIME="/MD" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="16" -DCONAN_CXX_FLAGS="/MP8" -DCONAN_C_FLAGS="/MP8" -DCMAKE_INSTALL_PREFIX="C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\package" -DCMAKE_INSTALL_BINDIR="bin" -DCMAKE_INSTALL_SBINDIR="bin" -DCMAKE_INSTALL_LIBEXECDIR="bin" -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_INSTALL_INCLUDEDIR="include" -DCMAKE_INSTALL_OLDINCLUDEDIR="include" -DCMAKE_INSTALL_DATAROOTDIR="share" -DCMAKE_PREFIX_PATH="C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_v1_package/build/37d05e9bf854940a923aa9dd6150375ddb4ee00f" -DCMAKE_MODULE_PATH="C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_v1_package/build/37d05e9bf854940a923aa9dd6150375ddb4ee00f" -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" -Wno-dev C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package
-----------------
-- The C compiler identification is MSVC 19.29.30147.0
-- The CXX compiler identification is MSVC 19.29.30147.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: called by CMake conan helper
-- Conan: Adjusting output directories
-- Conan: Using cmake targets configuration
-- Library DataFrame found C:/J/w/prod/BuildSingleReference@4/.conan/data/dataframe/2.0.0/_/_/package/127af201a4cdf8111e2e08540525c245c9b3b99e/lib/DataFrame.lib
-- Conan: Adjusting default RPATHs Conan policies
-- Conan: Adjusting language standard
-- Library DataFrame found C:/J/w/prod/BuildSingleReference@4/.conan/data/dataframe/2.0.0/_/_/package/127af201a4cdf8111e2e08540525c245c9b3b99e/lib/DataFrame.lib
-- Found: C:/J/w/prod/BuildSingleReference@4/.conan/data/dataframe/2.0.0/_/_/package/127af201a4cdf8111e2e08540525c245c9b3b99e/lib/DataFrame.lib
-- Configuring done
-- Generating done
-- Build files have been written to: C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_v1_package/build/37d05e9bf854940a923aa9dd6150375ddb4ee00f

----Running------
> cmake --build C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f --config Release -- /m:8 /verbosity:minimal
-----------------
Microsoft (R) Build Engine version 16.11.2+f32259642 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule C:/J/w/prod/BuildSingleReference@4/cci-7e472d50/recipes/dataframe/all/test_package/CMakeLists.txt
  test_package.cpp
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(223,24): error C2491: 'hmdf::HeteroConstPtrView<A>::HeteroConstPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(226,24): error C2491: 'hmdf::HeteroConstPtrView<A>::HeteroConstPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(231,24): error C2491: 'hmdf::HeteroConstPtrView<A>::HeteroConstPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(239,1): error C2491: 'hmdf::HeteroConstPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(257,1): error C2491: 'hmdf::HeteroConstPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstPtrView.tcc(274,29): error C2491: 'hmdf::HeteroConstPtrView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(212,21): error C2491: 'hmdf::HeteroConstView<A>::HeteroConstView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(216,1): error C2491: 'hmdf::HeteroConstView<A>::HeteroConstView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(218,21): error C2491: 'hmdf::HeteroConstView<A>::HeteroConstView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(224,1): error C2491: 'hmdf::HeteroConstView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(241,41): error C2491: 'hmdf::HeteroConstView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroConstView.tcc(258,26): error C2491: 'hmdf::HeteroConstView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(307,19): error C2491: 'hmdf::HeteroPtrView<A>::HeteroPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(310,19): error C2491: 'hmdf::HeteroPtrView<A>::HeteroPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(312,19): error C2491: 'hmdf::HeteroPtrView<A>::HeteroPtrView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(317,37): error C2491: 'hmdf::HeteroPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(334,37): error C2491: 'hmdf::HeteroPtrView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroPtrView.tcc(351,24): error C2491: 'hmdf::HeteroPtrView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(322,16): error C2491: 'hmdf::HeteroView<A>::HeteroView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(325,16): error C2491: 'hmdf::HeteroView<A>::HeteroView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(327,16): error C2491: 'hmdf::HeteroView<A>::HeteroView': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(332,31): error C2491: 'hmdf::HeteroView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(349,31): error C2491: 'hmdf::HeteroView<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroView.tcc(366,21): error C2491: 'hmdf::HeteroView<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(369,18): error C2491: 'hmdf::HeteroVector<A>::HeteroVector': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(379,18): error C2491: 'hmdf::HeteroVector<A>::HeteroVector': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(381,18): error C2491: 'hmdf::HeteroVector<A>::HeteroVector': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(386,35): error C2491: 'hmdf::HeteroVector<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(404,35): error C2491: 'hmdf::HeteroVector<A>::operator =': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Vectors/HeteroVector.tcc(422,23): error C2491: 'hmdf::HeteroVector<A>::clear': definition of dllimport function not allowed [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Utils/FixedSizeString.h(87,11): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
C:\J\w\prod\BuildSingleReference@4\.conan\data\dataframe\2.0.0\_\_\package\127af201a4cdf8111e2e08540525c245c9b3b99e\include\DataFrame/Utils/FixedSizeString.h(106,11): warning C4996: 'strcat': This function or variable may be unsafe. Consider using strcat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f\test_package\test_package.vcxproj]
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_DATAROOTDIR
    CMAKE_INSTALL_INCLUDEDIR
    CMAKE_INSTALL_LIBDIR
    CMAKE_INSTALL_LIBEXECDIR
    CMAKE_INSTALL_OLDINCLUDEDIR
    CMAKE_INSTALL_SBINDIR


ERROR: dataframe/2.0.0 (test package): Error in build() method, line 12
	cmake.build()
	ConanException: Error 1 while executing cmake --build C:\J\w\prod\BuildSingleReference@4\cci-7e472d50\recipes\dataframe\all\test_v1_package\build\37d05e9bf854940a923aa9dd6150375ddb4ee00f --config Release -- /m:8 /verbosity:minimal
```

</details>