### PR TITLE
Newlines at end of strings are unexpected

### DIFF
--- a/include/DataFrame/Internals/DataFrame_read.tcc
+++ b/include/DataFrame/Internals/DataFrame_read.tcc
@@ -1153,6 +1153,12 @@ read_csv2_(std::FILE *stream,
                     }
                 }
                 else if (col_spec.type_spec == "string")  {
+                    if (!value.empty() && value.back() == '\n') {
+                        value.pop_back();
+                    }
+                    if (!value.empty() && value.back() == '\r') {
+                        value.pop_back();
+                    }
                     std::any_cast<StlVecType<std::string> &>
                         (col_spec.col_vec).emplace_back(value);
                 }


### PR DESCRIPTION
I'm reading a CSV file `df.read("example.csv", io_format::csv2);`:
```
INDEX:4:<ulong>,column2:4:<int>,string_col:4:<string>
0,0,string 0
1,1,string 1
2,2,string 2
3,3,string 3
```
In the data frame, I have newlines `string 1\n` for the last column, which might not match other columns not at the end. For example, when trying to join on string columns.

Implemented the logic that Unix-style and Windows-style newlines will be trimmed.