### PR TITLE
Not a fix, but now at least MSVC2022 properly reports why it buggers the code.

### DIFF
--- a/include/DataFrame/Utils/Matrix.h
+++ b/include/DataFrame/Utils/Matrix.h
@@ -98,6 +98,13 @@ public:
     reference operator[] (size_type r, size_type c);
     const_reference operator[] (size_type r, size_type c) const;
 
+#if !defined(__cpp_multidimensional_subscript) || (defined(_MSC_VER) && _MSC_VER <= 1944 /* MSVC2022 v17.14.0 */ )
+#pragma message("Your compiler (MSVC2022?) does not fully support C++23: operator[] with multiple arguments is not properly supported as per https://en.cppreference.com/w/cpp/language/operators / https://isocpp.org/wiki/faq/operator-overloading#matrix-subscript-op / https://en.cppreference.com/w/cpp/feature_test#Language_features")
+#error Your compiler does not fully support C++23
+// the above code will now report:
+//   E0344: too many parameters for this operator function
+#endif
+
     // Set the given column or row from the given iterator.
     // col_data/row_Data iterators must be valid for the length of
     // columns/rows.


### PR DESCRIPTION
See also (experimental) commit: SHA-1: fbb4d54b66098b5e9643bd4f427435d71ba7e1f6:

	// MSVC2022 (in May 2025) spits out error E0344 for the 2-operand operator[] above.
	// (E0344: too many parameters for this `operator []` function detected during instantiation of class)
	//
	// In userland code this shows up as *subtle WARNINGS* such as:
	//
	//   warning C4548: expression before comma has no effect; expected expression with side-effect
	//
	// which may look benign to some of you, but certainly are NOT: these are the result of MSVC silently
	// discarding the second parameter of the operator[] functions! No compiler errors, just a few warnings
	// and then you wonder why your code fails at run-time...

This pullreq adds a bit of code to ensure your compiler spits out **errors** instead of mere `first part of comma expression has no effect` *warnings* (which you only saw anyway when the warning level is dialed up to a high level.)
