### PR TITLE
fix for MSVC2022 as that one does not **fully** support C++23 yet

### DIFF
--- a/include/DataFrame/Utils/Matrix.h
+++ b/include/DataFrame/Utils/Matrix.h
@@ -95,8 +95,16 @@ public:
     reference operator() (size_type r, size_type c);
     const_reference operator() (size_type r, size_type c) const;
 
-    reference operator[] (size_type r, size_type c);
+#if !defined(__cpp_multidimensional_subscript) || (defined(_MSC_VER) && _MSC_VER <= 1944 /* MSVC2022 v17.14.0 */ )
+#if 0
+#pragma message("Your compiler does not fully support C++23: operator[] with multiple arguments is not properly supported as per https://en.cppreference.com/w/cpp/language/operators / https://isocpp.org/wiki/faq/operator-overloading#matrix-subscript-op / https://en.cppreference.com/w/cpp/feature_test#Language_features")
+#endif
+	// the (disabled) code below will report:
+	//   E0344: too many parameters for this operator function
+#else
+	reference operator[] (size_type r, size_type c);
     const_reference operator[] (size_type r, size_type c) const;
+#endif
 
     // Set the given column or row from the given iterator.
     // col_data/row_Data iterators must be valid for the length of

--- a/test/matrix_tester.cc
+++ b/test/matrix_tester.cc
@@ -357,11 +357,11 @@ int main(int, char *[]) {
 
         assert(eigenvecs.cols() == 10);
         assert(eigenvecs.rows() == 10);
-        assert((std::fabs(eigenvecs[0, 0] - -0.00139238) < 0.000001));
-        assert((std::fabs(eigenvecs[2, 4] - -0.325968) < 0.00001));
-        assert((std::fabs(eigenvecs[5, 6] - 0.0349338) < 0.000001));
-        assert((std::fabs(eigenvecs[8, 2] - -0.285251) < 0.00001));
-        assert((std::fabs(eigenvecs[9, 9] - -0.51616) < 0.00001));
+        assert((std::fabs(eigenvecs(0, 0) - -0.00139238) < 0.000001));
+        assert((std::fabs(eigenvecs(2, 4) - -0.325968) < 0.00001));
+        assert((std::fabs(eigenvecs(5, 6) - 0.0349338) < 0.000001));
+        assert((std::fabs(eigenvecs(8, 2) - -0.285251) < 0.00001));
+        assert((std::fabs(eigenvecs(9, 9) - -0.51616) < 0.00001));
     }
 
     // Test Covariance matrix


### PR DESCRIPTION
(As announced in comment of https://github.com/hosseinmoein/DataFrame/pull/363)

fix / work-around for MSVC2022 as that one does not **fully** support C++23 yet (May 2022) as we get E0344 errors for the 2-dimensional `operator []` function instantiations. The 'fix' is more like a work-around: the `operator[]` member functions are discarded when compiling in MSVC2022 and all code uses the reference-returning `operator()` member functions instead, as suggested per C++ FAQ: https://isocpp.org/wiki/faq/operator-overloading#matrix-subscript-op

See also: https://github.com/hosseinmoein/DataFrame/pull/363, commit SHA-1: 283563f7aceef838c588b5dfcdb21e312aeaf52e , SHA-1: fbb4d54b66098b5e9643bd4f427435d71ba7e1f6