### PR TITLE
GCC 15/16 compiler error fix

### DIFF
--- a/include/DataFrame/Utils/PrettyPrint.h
+++ b/include/DataFrame/Utils/PrettyPrint.h
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <cstdio>
+#include <iomanip>
 #include <ios>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Starting with GCC 15, checks for header file inclusions and implicit declarations have become stricter, which has prevented DataFrame from compiling in our CI environment when using GCC 15 and 16:

```console
error: /__w/xmake-repo/xmake-repo/packages/d/dataframe/xmake.lua:75: ...amdir/core/sandbox/modules/import/core/tool/compiler.lua:84: @programdir/modules/core/tools/gcc.lua:1057: /github/home/.xmake/packages/d/dataframe/4.0.2/05ecf4c9247746fe8f7a1b0007b2568d/include/DataFrame/Utils/PrettyPrint.h:201:34: error: ‘setprecision’ is not a member of ‘std’ [-Wtemplate-body]
  201 |         ss << std::fixed << std::setprecision(precision);
      |                                  ^~~~~~~~~~~~
/github/home/.xmake/packages/d/dataframe/4.0.2/05ecf4c9247746fe8f7a1b0007b2568d/include/DataFrame/Utils/PrettyPrint.h:1:1: note: ‘std::setprecision’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
  +++ |+#include <iomanip>
    1 | // Hossein Moein
In file included from /github/home/.xmake/packages/d/dataframe/4.0.2/05ecf4c9247746fe8f7a1b0007b2568d/include/DataFrame/DataFrame.h:6997:
/github/home/.xmake/packages/d/dataframe/4.0.2/05ecf4c9247746fe8f7a1b0007b2568d/include/DataFrame/Internals/DataFrame_write.tcc: In member function ‘bool hmdf::DataFrame<I, H>::write(S&, hmdf::io_format, hmdf::WriteParams<>) const’:
/github/home/.xmake/packages/d/dataframe/4.0.2/05ecf4c9247746fe8f7a1b0007b2568d/include/DataFrame/Internals/DataFrame_write.tcc:328:27: error: ‘setw’ is not a member of ‘std’ [-Wtemplate-body]
  328 |                 o << std::setw(gutter_width) << row;
      |                           ^~~~
/github/home/.xmake/packages/d/dataframe/4.0.2/05ecf4c9247746fe8f7a1b0007b2568d/include/DataFrame/Internals/DataFrame_write.tcc:1:1: note: ‘std::setw’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
  +++ |+#include <iomanip>
    1 | // Hossein Moein
```

Including the missing header file can fix this.